### PR TITLE
Add support for pre-existing query items in the URL string

### DIFF
--- a/Sources/OAuth2/Connection.swift
+++ b/Sources/OAuth2/Connection.swift
@@ -33,7 +33,7 @@ public class Connection {
     
     var urlComponents = URLComponents(string: urlString)!
     
-    var queryItems: [URLQueryItem] = []
+    var queryItems: [URLQueryItem] = urlComponents.queryItems ?? []
     for (key, value) in parameters {
       queryItems.append(URLQueryItem(name: key, value: value))
     }


### PR DESCRIPTION
The parameters dictionary does not allow multiple query items with the same key.
I ran into the problem while working with the [Google Sheets `batchGet` request](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/batchGet), which supports using multiple `ranges`.
I think it would generally be nice for `performRequest`  to take `[URLQueryItem]` or `[(key: String, value: String)]` instead of `[String: String]`