### PR TITLE
Add PlatformNativeTokenProvider using the AuthenticationServices framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Package.resolved
 .swiftpm
+.build

--- a/Examples/GAuth-Apple/.gitignore
+++ b/Examples/GAuth-Apple/.gitignore
@@ -1,0 +1,23 @@
+## User settings
+xcuserdata/
+
+## Code signing
+*.cer
+*.mobileprovision
+*.provisionprofile
+
+## App packaging
+*.app
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+.build/
+
+# Finder excrement
+.DS_Store

--- a/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.pbxproj
+++ b/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.pbxproj
@@ -1,0 +1,588 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		705A071027445B9800BEF60A /* GoogleAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 705A070F27445B9800BEF60A /* GoogleAPIRuntime */; };
+		705A071227445C0B00BEF60A /* GoogleAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 705A071127445C0B00BEF60A /* GoogleAPIRuntime */; };
+		705A071827471D6B00BEF60A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70988A3927443D2E001F41D6 /* ContentView.swift */; };
+		705A071927471DC700BEF60A /* GAuthDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709889F92742F778001F41D6 /* GAuthDemoApp.swift */; };
+		705A071D274C184600BEF60A /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A071C274C184600BEF60A /* WindowAccessor.swift */; };
+		705A071F274C18CF00BEF60A /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A071E274C18CF00BEF60A /* WindowAccessor.swift */; };
+		709889FA2742F778001F41D6 /* GAuthDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709889F92742F778001F41D6 /* GAuthDemoApp.swift */; };
+		709889FE2742F77A001F41D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 709889FD2742F77A001F41D6 /* Assets.xcassets */; };
+		70988A012742F77A001F41D6 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 70988A002742F77A001F41D6 /* Preview Assets.xcassets */; };
+		70988A30274439A9001F41D6 /* gmailv1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70988A082743037E001F41D6 /* gmailv1.swift */; };
+		70988A3A27443D2E001F41D6 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70988A3927443D2E001F41D6 /* ContentView.swift */; };
+		70988A3C27443D2F001F41D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 70988A3B27443D2F001F41D6 /* Assets.xcassets */; };
+		70988A3F27443D2F001F41D6 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 70988A3E27443D2F001F41D6 /* Preview Assets.xcassets */; };
+		70988A44274450E5001F41D6 /* gmailv1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70988A082743037E001F41D6 /* gmailv1.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		70988A2E27441C76001F41D6 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		70083F53274C5A15007195C3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		705A071B27486E7900BEF60A /* .. */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ..; path = ../..; sourceTree = "<group>"; };
+		705A071C274C184600BEF60A /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
+		705A071E274C18CF00BEF60A /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
+		709889F62742F778001F41D6 /* GAuth-macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "GAuth-macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		709889F92742F778001F41D6 /* GAuthDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GAuthDemoApp.swift; sourceTree = "<group>"; };
+		709889FD2742F77A001F41D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		70988A002742F77A001F41D6 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		70988A022742F77A001F41D6 /* gauth-macos.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "gauth-macos.entitlements"; sourceTree = "<group>"; };
+		70988A082743037E001F41D6 /* gmailv1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = gmailv1.swift; sourceTree = "<group>"; };
+		70988A3527443D2E001F41D6 /* GAuth-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "GAuth-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		70988A3927443D2E001F41D6 /* ContentView.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; tabWidth = 2; };
+		70988A3B27443D2F001F41D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		70988A3E27443D2F001F41D6 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		709889F32742F778001F41D6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				705A071227445C0B00BEF60A /* GoogleAPIRuntime in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		70988A3227443D2E001F41D6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				705A071027445B9800BEF60A /* GoogleAPIRuntime in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		705A071A27486E7900BEF60A /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				705A071B27486E7900BEF60A /* .. */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		709889ED2742F778001F41D6 = {
+			isa = PBXGroup;
+			children = (
+				705A071A27486E7900BEF60A /* Packages */,
+				70988A43274450D8001F41D6 /* Shared */,
+				709889F82742F778001F41D6 /* GAuth-macOS */,
+				70988A3627443D2E001F41D6 /* GAuth-iOS */,
+				709889F72742F778001F41D6 /* Products */,
+				70988A4527445258001F41D6 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		709889F72742F778001F41D6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				709889F62742F778001F41D6 /* GAuth-macOS.app */,
+				70988A3527443D2E001F41D6 /* GAuth-iOS.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		709889F82742F778001F41D6 /* GAuth-macOS */ = {
+			isa = PBXGroup;
+			children = (
+				70083F53274C5A15007195C3 /* Info.plist */,
+				709889FD2742F77A001F41D6 /* Assets.xcassets */,
+				70988A022742F77A001F41D6 /* gauth-macos.entitlements */,
+				709889FF2742F77A001F41D6 /* Preview Content */,
+				705A071E274C18CF00BEF60A /* WindowAccessor.swift */,
+			);
+			path = "GAuth-macOS";
+			sourceTree = "<group>";
+		};
+		709889FF2742F77A001F41D6 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				70988A002742F77A001F41D6 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		70988A3627443D2E001F41D6 /* GAuth-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				70988A3B27443D2F001F41D6 /* Assets.xcassets */,
+				70988A3D27443D2F001F41D6 /* Preview Content */,
+				705A071C274C184600BEF60A /* WindowAccessor.swift */,
+			);
+			path = "GAuth-iOS";
+			sourceTree = "<group>";
+		};
+		70988A3D27443D2F001F41D6 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				70988A3E27443D2F001F41D6 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		70988A43274450D8001F41D6 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				70988A3927443D2E001F41D6 /* ContentView.swift */,
+				709889F92742F778001F41D6 /* GAuthDemoApp.swift */,
+				70988A082743037E001F41D6 /* gmailv1.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		70988A4527445258001F41D6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		709889F52742F778001F41D6 /* GAuth-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 70988A052742F77A001F41D6 /* Build configuration list for PBXNativeTarget "GAuth-macOS" */;
+			buildPhases = (
+				709889F22742F778001F41D6 /* Sources */,
+				709889F32742F778001F41D6 /* Frameworks */,
+				709889F42742F778001F41D6 /* Resources */,
+				70988A2E27441C76001F41D6 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "GAuth-macOS";
+			packageProductDependencies = (
+				705A071127445C0B00BEF60A /* GoogleAPIRuntime */,
+			);
+			productName = "gmail-test";
+			productReference = 709889F62742F778001F41D6 /* GAuth-macOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		70988A3427443D2E001F41D6 /* GAuth-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 70988A4027443D2F001F41D6 /* Build configuration list for PBXNativeTarget "GAuth-iOS" */;
+			buildPhases = (
+				70988A3127443D2E001F41D6 /* Sources */,
+				70988A3227443D2E001F41D6 /* Frameworks */,
+				70988A3327443D2E001F41D6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "GAuth-iOS";
+			packageProductDependencies = (
+				705A070F27445B9800BEF60A /* GoogleAPIRuntime */,
+			);
+			productName = "Gmail iOS";
+			productReference = 70988A3527443D2E001F41D6 /* GAuth-iOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		709889EE2742F778001F41D6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1310;
+				LastUpgradeCheck = 1310;
+				TargetAttributes = {
+					709889F52742F778001F41D6 = {
+						CreatedOnToolsVersion = 13.1;
+					};
+					70988A3427443D2E001F41D6 = {
+						CreatedOnToolsVersion = 13.1;
+					};
+				};
+			};
+			buildConfigurationList = 709889F12742F778001F41D6 /* Build configuration list for PBXProject "GAuth-Apple" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 709889ED2742F778001F41D6;
+			packageReferences = (
+				705A070E27445B9800BEF60A /* XCRemoteSwiftPackageReference "google-api-swift-client" */,
+			);
+			productRefGroup = 709889F72742F778001F41D6 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				709889F52742F778001F41D6 /* GAuth-macOS */,
+				70988A3427443D2E001F41D6 /* GAuth-iOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		709889F42742F778001F41D6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				70988A012742F77A001F41D6 /* Preview Assets.xcassets in Resources */,
+				709889FE2742F77A001F41D6 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		70988A3327443D2E001F41D6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				70988A3F27443D2F001F41D6 /* Preview Assets.xcassets in Resources */,
+				70988A3C27443D2F001F41D6 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		709889F22742F778001F41D6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				70988A30274439A9001F41D6 /* gmailv1.swift in Sources */,
+				705A071827471D6B00BEF60A /* ContentView.swift in Sources */,
+				705A071F274C18CF00BEF60A /* WindowAccessor.swift in Sources */,
+				709889FA2742F778001F41D6 /* GAuthDemoApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		70988A3127443D2E001F41D6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				70988A44274450E5001F41D6 /* gmailv1.swift in Sources */,
+				705A071927471DC700BEF60A /* GAuthDemoApp.swift in Sources */,
+				705A071D274C184600BEF60A /* WindowAccessor.swift in Sources */,
+				70988A3A27443D2E001F41D6 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		70988A032742F77A001F41D6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		70988A042742F77A001F41D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		70988A062742F77A001F41D6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "GAuth-macOS/gauth-macos.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "GAuth-macOS/Preview\\ Content/Preview\\ Assets.xcassets";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "GAuth-macOS/Info.plist";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.gauth-macos";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		70988A072742F77A001F41D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "GAuth-macOS/gauth-macos.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "GAuth-macOS/Preview\\ Content/Preview\\ Assets.xcassets";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "GAuth-macOS/Info.plist";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.gauth-macos";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		70988A4127443D2F001F41D6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "GAuth-iOS/Preview\\ Content/Preview\\ Assets.xcassets";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.gauth-ios";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		70988A4227443D2F001F41D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "GAuth-iOS/Preview\\ Content/Preview\\ Assets.xcassets";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.gauth-ios";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		709889F12742F778001F41D6 /* Build configuration list for PBXProject "GAuth-Apple" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				70988A032742F77A001F41D6 /* Debug */,
+				70988A042742F77A001F41D6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		70988A052742F77A001F41D6 /* Build configuration list for PBXNativeTarget "GAuth-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				70988A062742F77A001F41D6 /* Debug */,
+				70988A072742F77A001F41D6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		70988A4027443D2F001F41D6 /* Build configuration list for PBXNativeTarget "GAuth-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				70988A4127443D2F001F41D6 /* Debug */,
+				70988A4227443D2F001F41D6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		705A070E27445B9800BEF60A /* XCRemoteSwiftPackageReference "google-api-swift-client" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/googleapis/google-api-swift-client";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		705A070F27445B9800BEF60A /* GoogleAPIRuntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 705A070E27445B9800BEF60A /* XCRemoteSwiftPackageReference "google-api-swift-client" */;
+			productName = GoogleAPIRuntime;
+		};
+		705A071127445C0B00BEF60A /* GoogleAPIRuntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 705A070E27445B9800BEF60A /* XCRemoteSwiftPackageReference "google-api-swift-client" */;
+			productName = GoogleAPIRuntime;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 709889EE2742F778001F41D6 /* Project object */;
+}

--- a/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.pbxproj
+++ b/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 
 /* Begin PBXFileReference section */
 		70083F53274C5A15007195C3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		70083F5427556FDB007195C3 /* GAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GAuth.swift; sourceTree = "<group>"; };
+		70083F5427556FDB007195C3 /* GAuth.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = GAuth.swift; sourceTree = "<group>"; tabWidth = 2; };
 		705A071B27486E7900BEF60A /* .. */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ..; path = ../..; sourceTree = "<group>"; };
 		705A071C274C184600BEF60A /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		705A071E274C18CF00BEF60A /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };

--- a/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.pbxproj
+++ b/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		70083F5527556FDB007195C3 /* GAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70083F5427556FDB007195C3 /* GAuth.swift */; };
+		70083F5627556FDB007195C3 /* GAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70083F5427556FDB007195C3 /* GAuth.swift */; };
 		705A071027445B9800BEF60A /* GoogleAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 705A070F27445B9800BEF60A /* GoogleAPIRuntime */; };
 		705A071227445C0B00BEF60A /* GoogleAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 705A071127445C0B00BEF60A /* GoogleAPIRuntime */; };
 		705A071827471D6B00BEF60A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70988A3927443D2E001F41D6 /* ContentView.swift */; };
@@ -38,6 +40,7 @@
 
 /* Begin PBXFileReference section */
 		70083F53274C5A15007195C3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		70083F5427556FDB007195C3 /* GAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GAuth.swift; sourceTree = "<group>"; };
 		705A071B27486E7900BEF60A /* .. */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ..; path = ../..; sourceTree = "<group>"; };
 		705A071C274C184600BEF60A /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		705A071E274C18CF00BEF60A /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
@@ -146,6 +149,7 @@
 				70988A3927443D2E001F41D6 /* ContentView.swift */,
 				709889F92742F778001F41D6 /* GAuthDemoApp.swift */,
 				70988A082743037E001F41D6 /* gmailv1.swift */,
+				70083F5427556FDB007195C3 /* GAuth.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -271,6 +275,7 @@
 				705A071827471D6B00BEF60A /* ContentView.swift in Sources */,
 				705A071F274C18CF00BEF60A /* WindowAccessor.swift in Sources */,
 				709889FA2742F778001F41D6 /* GAuthDemoApp.swift in Sources */,
+				70083F5527556FDB007195C3 /* GAuth.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -282,6 +287,7 @@
 				705A071927471DC700BEF60A /* GAuthDemoApp.swift in Sources */,
 				705A071D274C184600BEF60A /* WindowAccessor.swift in Sources */,
 				70988A3A27443D2E001F41D6 /* ContentView.swift in Sources */,
+				70083F5627556FDB007195C3 /* GAuth.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/xcshareddata/xcschemes/GAuth iOS.xcscheme
+++ b/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/xcshareddata/xcschemes/GAuth iOS.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "70988A3427443D2E001F41D6"
+               BuildableName = "GAuth-iOS.app"
+               BlueprintName = "GAuth-iOS"
+               ReferencedContainer = "container:GAuth-Apple.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "70988A3427443D2E001F41D6"
+            BuildableName = "GAuth-iOS.app"
+            BlueprintName = "GAuth-iOS"
+            ReferencedContainer = "container:GAuth-Apple.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "70988A3427443D2E001F41D6"
+            BuildableName = "GAuth-iOS.app"
+            BlueprintName = "GAuth-iOS"
+            ReferencedContainer = "container:GAuth-Apple.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/xcshareddata/xcschemes/GAuth macOS.xcscheme
+++ b/Examples/GAuth-Apple/GAuth-Apple.xcodeproj/xcshareddata/xcschemes/GAuth macOS.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "709889F52742F778001F41D6"
+               BuildableName = "GAuth-macOS.app"
+               BlueprintName = "GAuth-macOS"
+               ReferencedContainer = "container:GAuth-Apple.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "709889F52742F778001F41D6"
+            BuildableName = "GAuth-macOS.app"
+            BlueprintName = "GAuth-macOS"
+            ReferencedContainer = "container:GAuth-Apple.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "709889F52742F778001F41D6"
+            BuildableName = "GAuth-macOS.app"
+            BlueprintName = "GAuth-macOS"
+            ReferencedContainer = "container:GAuth-Apple.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/GAuth-Apple/GAuth-iOS/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/GAuth-Apple/GAuth-iOS/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/GAuth-Apple/GAuth-iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/GAuth-Apple/GAuth-iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/GAuth-Apple/GAuth-iOS/Assets.xcassets/Contents.json
+++ b/Examples/GAuth-Apple/GAuth-iOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/GAuth-Apple/GAuth-iOS/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Examples/GAuth-Apple/GAuth-iOS/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/GAuth-Apple/GAuth-iOS/WindowAccessor.swift
+++ b/Examples/GAuth-Apple/GAuth-iOS/WindowAccessor.swift
@@ -1,0 +1,29 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+struct WindowAccessor: UIViewRepresentable {
+  @Binding var window: UIWindow?
+
+  func makeUIView(context: Context) -> UIView {
+    let view = UIView()
+    DispatchQueue.main.async {
+      self.window = view.window   // << right after inserted in window
+    }
+    return view
+  }
+
+  func updateUIView(_ uiView: UIView, context: Context) {}
+}

--- a/Examples/GAuth-Apple/GAuth-macOS/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/GAuth-Apple/GAuth-macOS/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/GAuth-Apple/GAuth-macOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/GAuth-Apple/GAuth-macOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/GAuth-Apple/GAuth-macOS/Assets.xcassets/Contents.json
+++ b/Examples/GAuth-Apple/GAuth-macOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/GAuth-Apple/GAuth-macOS/Info.plist
+++ b/Examples/GAuth-Apple/GAuth-macOS/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict/>
+</dict>
+</plist>

--- a/Examples/GAuth-Apple/GAuth-macOS/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Examples/GAuth-Apple/GAuth-macOS/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/GAuth-Apple/GAuth-macOS/WindowAccessor.swift
+++ b/Examples/GAuth-Apple/GAuth-macOS/WindowAccessor.swift
@@ -1,0 +1,29 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+struct WindowAccessor: NSViewRepresentable {
+  @Binding var window: NSWindow?
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    DispatchQueue.main.async {
+      self.window = view.window   // << right after inserted in window
+    }
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {}
+}

--- a/Examples/GAuth-Apple/GAuth-macOS/gauth-macos.entitlements
+++ b/Examples/GAuth-Apple/GAuth-macOS/gauth-macos.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/GAuth-Apple/Shared/ContentView.swift
+++ b/Examples/GAuth-Apple/Shared/ContentView.swift
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import SwiftUI
-import OAuth2
 import AuthenticationServices
+import SwiftUI
 
 struct ContentView: View {
 
@@ -46,103 +45,6 @@ struct ContentView: View {
     }
     .padding()
     .background(WindowAccessor(window: $window))
-  }
-}
-
-// MARK: oauth2 browser
-
-#error("add OAuth2 <client_id> from https://console.cloud.google.com/apis/credentials")
-let creds = """
-{
-  "client_id": "<client of type native/iosOS>",
-  "client_secret": "",
-  "authorize_url": "https://accounts.google.com/o/oauth2/auth",
-  "access_token_url": "https://accounts.google.com/o/oauth2/token",
-  "callback": "/google/callback"
-}
-"""
-
-func oauth2_browser() {
-  let cdata = creds.data(using: .utf8)!
-  guard let tp = BrowserTokenProvider(credentials: cdata, token: "")
-  else {
-    print("error creating browser token provider")
-    return
-  }
-  do {
-    let readonly = "https://www.googleapis.com/auth/gmail.readonly"
-    try tp.signIn(scopes: [readonly])
-  } catch let e {
-    print("error signing in: \(e)")
-    return
-  }
-
-  query_gmail(tp)
-}
-
-// MARK: oauth2 native
-
-#error("add OAuth2 <client_id> and <callback_scheme> from https://console.cloud.google.com/apis/credentials")
-let creds_native = """
-{
-  "client_id": "<client of type native/iOS>",
-  "authorize_url": "https://accounts.google.com/o/oauth2/auth",
-  "access_token_url": "https://accounts.google.com/o/oauth2/token",
-  "callback_scheme": "<labeled: iOS URL Scheme, the reversed client-id>"
-}
-"""
-
-func oauth2_native(anchor a: ASPresentationAnchor) {
-  let cdata = creds_native.data(using: .utf8)!
-  guard let tp = PlatformNativeTokenProvider(credentials: cdata, token: "")
-  else {
-    print("error creating browser token provider")
-    return
-  }
-  let readonly = "https://www.googleapis.com/auth/gmail.readonly"
-
-  let ctx = AuthContext(anchor: a)
-  tp.signIn(scopes: [readonly], context: ctx) {
-    if let token = $0 {
-      print("token: \(token)")
-      query_gmail(tp)
-    } else {
-      print("error signing in: \($1!)")
-    }
-  }
-}
-
-class AuthContext: NSObject, ASWebAuthenticationPresentationContextProviding {
-  let anchor: ASPresentationAnchor
-  init(anchor: ASPresentationAnchor) {
-    self.anchor = anchor
-  }
-  func presentationAnchor(for session: ASWebAuthenticationSession)
-  -> ASPresentationAnchor {
-    return self.anchor
-  }
-}
-
-// MARK: query gmail
-
-func query_gmail(_ tp: TokenProvider) {
-  print("Listing Gmail Messages")
-  let g = Gmail(tokenProvider: tp)
-  do {
-    let params = Gmail.users_messageslistParameters(
-      includeSpamTrash: false,
-      labelIds: nil,
-      maxResults: 50,
-      pageToken: nil,
-      q: nil,
-      userId: "me"
-    )
-    try g.users_messages_list(parameters: params) { resp, err in
-      resp.map { print("Response: \n\($0)") }
-      err.map { print("Error: \n\($0)") }
-    }
-  } catch let e {
-    print("error listing messages: \(e)")
   }
 }
 

--- a/Examples/GAuth-Apple/Shared/ContentView.swift
+++ b/Examples/GAuth-Apple/Shared/ContentView.swift
@@ -1,0 +1,155 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+import OAuth2
+import AuthenticationServices
+
+struct ContentView: View {
+
+  @State private var window: ASPresentationAnchor?
+
+  var body: some View {
+    VStack {
+      HStack { Spacer().frame(maxWidth: .infinity) }
+      Text("GAuth Example")
+      Divider()
+      Spacer()
+
+      Button(action: {
+        oauth2_browser()
+      }) {
+        Text("Login Browser")
+      }
+
+      Divider()
+        .padding()
+        .frame(maxWidth: 120)
+
+      Button(action: {
+        oauth2_native(anchor: window!)
+      }) {
+        Text("Login Native")
+      }
+      Spacer()
+    }
+    .padding()
+    .background(WindowAccessor(window: $window))
+  }
+}
+
+// MARK: oauth2 browser
+
+#error("add OAuth2 <client_id> from https://console.cloud.google.com/apis/credentials")
+let creds = """
+{
+  "client_id": "<client of type native/iosOS>",
+  "client_secret": "",
+  "authorize_url": "https://accounts.google.com/o/oauth2/auth",
+  "access_token_url": "https://accounts.google.com/o/oauth2/token",
+  "callback": "/google/callback"
+}
+"""
+
+func oauth2_browser() {
+  let cdata = creds.data(using: .utf8)!
+  guard let tp = BrowserTokenProvider(credentials: cdata, token: "")
+  else {
+    print("error creating browser token provider")
+    return
+  }
+  do {
+    let readonly = "https://www.googleapis.com/auth/gmail.readonly"
+    try tp.signIn(scopes: [readonly])
+  } catch let e {
+    print("error signing in: \(e)")
+    return
+  }
+
+  query_gmail(tp)
+}
+
+// MARK: oauth2 native
+
+#error("add OAuth2 <client_id> and <callback_scheme> from https://console.cloud.google.com/apis/credentials")
+let creds_native = """
+{
+  "client_id": "<client of type native/iOS>",
+  "authorize_url": "https://accounts.google.com/o/oauth2/auth",
+  "access_token_url": "https://accounts.google.com/o/oauth2/token",
+  "callback_scheme": "<labeled: iOS URL Scheme, the reversed client-id>"
+}
+"""
+
+func oauth2_native(anchor a: ASPresentationAnchor) {
+  let cdata = creds_native.data(using: .utf8)!
+  guard let tp = PlatformNativeTokenProvider(credentials: cdata, token: "")
+  else {
+    print("error creating browser token provider")
+    return
+  }
+  let readonly = "https://www.googleapis.com/auth/gmail.readonly"
+
+  let ctx = AuthContext(anchor: a)
+  tp.signIn(scopes: [readonly], context: ctx) {
+    if let token = $0 {
+      print("token: \(token)")
+      query_gmail(tp)
+    } else {
+      print("error signing in: \($1!)")
+    }
+  }
+}
+
+class AuthContext: NSObject, ASWebAuthenticationPresentationContextProviding {
+  let anchor: ASPresentationAnchor
+  init(anchor: ASPresentationAnchor) {
+    self.anchor = anchor
+  }
+  func presentationAnchor(for session: ASWebAuthenticationSession)
+  -> ASPresentationAnchor {
+    return self.anchor
+  }
+}
+
+// MARK: query gmail
+
+func query_gmail(_ tp: TokenProvider) {
+  print("Listing Gmail Messages")
+  let g = Gmail(tokenProvider: tp)
+  do {
+    let params = Gmail.users_messageslistParameters(
+      includeSpamTrash: false,
+      labelIds: nil,
+      maxResults: 50,
+      pageToken: nil,
+      q: nil,
+      userId: "me"
+    )
+    try g.users_messages_list(parameters: params) { resp, err in
+      resp.map { print("Response: \n\($0)") }
+      err.map { print("Error: \n\($0)") }
+    }
+  } catch let e {
+    print("error listing messages: \(e)")
+  }
+}
+
+// MARK: previews
+
+struct ContentView_Previews: PreviewProvider {
+  static var previews: some View {
+    ContentView()
+  }
+}

--- a/Examples/GAuth-Apple/Shared/ContentView.swift
+++ b/Examples/GAuth-Apple/Shared/ContentView.swift
@@ -42,6 +42,12 @@ struct ContentView: View {
         Text("Login Native")
       }
       Spacer()
+      Button {
+        token_cache_clear()
+      } label: {
+        Text("Clear Token Cache")
+      }
+
     }
     .padding()
     .background(WindowAccessor(window: $window))

--- a/Examples/GAuth-Apple/Shared/GAuth.swift
+++ b/Examples/GAuth-Apple/Shared/GAuth.swift
@@ -1,0 +1,140 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import AuthenticationServices
+import Foundation
+import OAuth2
+
+// MARK: setup overview
+
+// You'll want to create a new demo/example project in the cloud console. Then,
+// navigate to the cloud console api credentials page and configure the consent
+// screen. A workspace internal screen will get you going quickly and does not
+// require review, however you'll only be able to use your own workspace email
+// addresses to complete the oauth flow until you configure an external screen.
+//
+//     https://console.cloud.google.com/apis/credentials
+//
+// Create an OAuth client ID crediential. An iOS credential works fine for both
+// these example flows (the browser flow doesn't need a "browser" credential).
+//
+// Plug the correct credential values into the inline JSON below. You
+// can copy the correct values from the console UI or download the credential
+// file and take the values from there.
+//
+// Enable the appropriate API for your project in the cloud console. This
+// example uses the Gmail API to get a list of your 50 most recent message IDs.
+//
+//     https://console.cloud.google.com/apis/library/gmail.googleapis.com
+//
+// Review the Google OAuth2 overview for further details:
+//
+//     https://developers.google.com/identity/protocols/oauth2
+
+// MARK: oauth2 browser
+
+#error("add OAuth2 <client_id> from cloud console api credentials page")
+let creds_browser = """
+{
+  "client_id": "<client of type native/iosOS>",
+  "client_secret": "",
+  "authorize_url": "https://accounts.google.com/o/oauth2/auth",
+  "access_token_url": "https://accounts.google.com/o/oauth2/token",
+  "callback": "/google/callback"
+}
+"""
+
+func oauth2_browser() {
+  let cdata = creds_browser.data(using: .utf8)!
+  guard let tp = BrowserTokenProvider(credentials: cdata, token: "")
+  else {
+    print("error creating browser token provider")
+    return
+  }
+  do {
+    let readonly = "https://www.googleapis.com/auth/gmail.readonly"
+    try tp.signIn(scopes: [readonly])
+  } catch let e {
+    print("error signing in: \(e)")
+    return
+  }
+
+  query_gmail(tp)
+}
+
+// MARK: oauth2 native
+
+#error("add OAuth2 <client_id> and <callback_scheme> from cloud console api credentials page")
+let creds_native = """
+{
+  "client_id": "<client of type native/iOS>",
+  "authorize_url": "https://accounts.google.com/o/oauth2/auth",
+  "access_token_url": "https://accounts.google.com/o/oauth2/token",
+  "callback_scheme": "<labeled: iOS URL Scheme, the reversed client-id>"
+}
+"""
+
+func oauth2_native(anchor a: ASPresentationAnchor) {
+  let cdata = creds_native.data(using: .utf8)!
+  guard let tp = PlatformNativeTokenProvider(credentials: cdata, token: "")
+  else {
+    print("error creating browser token provider")
+    return
+  }
+  let readonly = "https://www.googleapis.com/auth/gmail.readonly"
+
+  let ctx = AuthContext(anchor: a)
+  tp.signIn(scopes: [readonly], context: ctx) {
+    if let token = $0 {
+      print("token: \(token)")
+      query_gmail(tp)
+    } else {
+      print("error signing in: \($1!)")
+    }
+  }
+}
+
+class AuthContext: NSObject, ASWebAuthenticationPresentationContextProviding {
+  let anchor: ASPresentationAnchor
+  init(anchor: ASPresentationAnchor) {
+    self.anchor = anchor
+  }
+  func presentationAnchor(for session: ASWebAuthenticationSession)
+  -> ASPresentationAnchor {
+    return self.anchor
+  }
+}
+
+// MARK: query gmail
+
+func query_gmail(_ tp: TokenProvider) {
+  print("Listing Gmail Messages")
+  let g = Gmail(tokenProvider: tp)
+  do {
+    let params = Gmail.users_messageslistParameters(
+      includeSpamTrash: false,
+      labelIds: nil,
+      maxResults: 50,
+      pageToken: nil,
+      q: nil,
+      userId: "me"
+    )
+    try g.users_messages_list(parameters: params) { resp, err in
+      resp.map { print("Response: \n\($0)") }
+      err.map { print("Error: \n\($0)") }
+    }
+  } catch let e {
+    print("error listing messages: \(e)")
+  }
+}

--- a/Examples/GAuth-Apple/Shared/GAuthDemoApp.swift
+++ b/Examples/GAuth-Apple/Shared/GAuthDemoApp.swift
@@ -1,0 +1,24 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+@main
+struct GAuthDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Examples/GAuth-Apple/Shared/gmailv1.swift
+++ b/Examples/GAuth-Apple/Shared/gmailv1.swift
@@ -1,0 +1,2488 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is automatically-generated!
+//
+// see: https://github.com/googleapis/google-api-swift-client
+
+import Foundation
+import OAuth2
+import GoogleAPIRuntime
+
+public class Gmail : Service {
+    public init(tokenProvider: TokenProvider) {
+        super.init(tokenProvider, "https://gmail.googleapis.com/")
+    }
+
+    public class AutoForwarding: Codable {
+        public init (`disposition`: String?, `emailAddress`: String?, `enabled`: Bool?) {
+            self.`disposition` = `disposition`
+            self.`emailAddress` = `emailAddress`
+            self.`enabled` = `enabled`
+        }
+        public var `disposition`: String?
+        public var `emailAddress`: String?
+        public var `enabled`: Bool?
+    }
+
+    public class BatchDeleteMessagesRequest: Codable {
+        public init (`ids`: [String]?) {
+            self.`ids` = `ids`
+        }
+        public var `ids`: [String]?
+    }
+
+    public class BatchModifyMessagesRequest: Codable {
+        public init (`addLabelIds`: [String]?, `ids`: [String]?, `removeLabelIds`: [String]?) {
+            self.`addLabelIds` = `addLabelIds`
+            self.`ids` = `ids`
+            self.`removeLabelIds` = `removeLabelIds`
+        }
+        public var `addLabelIds`: [String]?
+        public var `ids`: [String]?
+        public var `removeLabelIds`: [String]?
+    }
+
+    public class Delegate: Codable {
+        public init (`delegateEmail`: String?, `verificationStatus`: String?) {
+            self.`delegateEmail` = `delegateEmail`
+            self.`verificationStatus` = `verificationStatus`
+        }
+        public var `delegateEmail`: String?
+        public var `verificationStatus`: String?
+    }
+
+    public class Draft: Codable {
+        public init (`id`: String?, `message`: Message?) {
+            self.`id` = `id`
+            self.`message` = `message`
+        }
+        public var `id`: String?
+        public var `message`: Message?
+    }
+
+    public class Filter: Codable {
+        public init (`action`: FilterAction?, `criteria`: FilterCriteria?, `id`: String?) {
+            self.`action` = `action`
+            self.`criteria` = `criteria`
+            self.`id` = `id`
+        }
+        public var `action`: FilterAction?
+        public var `criteria`: FilterCriteria?
+        public var `id`: String?
+    }
+
+    public class FilterAction: Codable {
+        public init (`addLabelIds`: [String]?, `forward`: String?, `removeLabelIds`: [String]?) {
+            self.`addLabelIds` = `addLabelIds`
+            self.`forward` = `forward`
+            self.`removeLabelIds` = `removeLabelIds`
+        }
+        public var `addLabelIds`: [String]?
+        public var `forward`: String?
+        public var `removeLabelIds`: [String]?
+    }
+
+    public class FilterCriteria: Codable {
+        public init (`excludeChats`: Bool?, `from`: String?, `hasAttachment`: Bool?, `negatedQuery`: String?, `query`: String?, `size`: Int?, `sizeComparison`: String?, `subject`: String?, `to`: String?) {
+            self.`excludeChats` = `excludeChats`
+            self.`from` = `from`
+            self.`hasAttachment` = `hasAttachment`
+            self.`negatedQuery` = `negatedQuery`
+            self.`query` = `query`
+            self.`size` = `size`
+            self.`sizeComparison` = `sizeComparison`
+            self.`subject` = `subject`
+            self.`to` = `to`
+        }
+        public var `excludeChats`: Bool?
+        public var `from`: String?
+        public var `hasAttachment`: Bool?
+        public var `negatedQuery`: String?
+        public var `query`: String?
+        public var `size`: Int?
+        public var `sizeComparison`: String?
+        public var `subject`: String?
+        public var `to`: String?
+    }
+
+    public class ForwardingAddress: Codable {
+        public init (`forwardingEmail`: String?, `verificationStatus`: String?) {
+            self.`forwardingEmail` = `forwardingEmail`
+            self.`verificationStatus` = `verificationStatus`
+        }
+        public var `forwardingEmail`: String?
+        public var `verificationStatus`: String?
+    }
+
+    public class History: Codable {
+        public init (`id`: String?, `labelsAdded`: [HistoryLabelAdded]?, `labelsRemoved`: [HistoryLabelRemoved]?, `messages`: [Message]?, `messagesAdded`: [HistoryMessageAdded]?, `messagesDeleted`: [HistoryMessageDeleted]?) {
+            self.`id` = `id`
+            self.`labelsAdded` = `labelsAdded`
+            self.`labelsRemoved` = `labelsRemoved`
+            self.`messages` = `messages`
+            self.`messagesAdded` = `messagesAdded`
+            self.`messagesDeleted` = `messagesDeleted`
+        }
+        public var `id`: String?
+        public var `labelsAdded`: [HistoryLabelAdded]?
+        public var `labelsRemoved`: [HistoryLabelRemoved]?
+        public var `messages`: [Message]?
+        public var `messagesAdded`: [HistoryMessageAdded]?
+        public var `messagesDeleted`: [HistoryMessageDeleted]?
+    }
+
+    public class HistoryLabelAdded: Codable {
+        public init (`labelIds`: [String]?, `message`: Message?) {
+            self.`labelIds` = `labelIds`
+            self.`message` = `message`
+        }
+        public var `labelIds`: [String]?
+        public var `message`: Message?
+    }
+
+    public class HistoryLabelRemoved: Codable {
+        public init (`labelIds`: [String]?, `message`: Message?) {
+            self.`labelIds` = `labelIds`
+            self.`message` = `message`
+        }
+        public var `labelIds`: [String]?
+        public var `message`: Message?
+    }
+
+    public class HistoryMessageAdded: Codable {
+        public init (`message`: Message?) {
+            self.`message` = `message`
+        }
+        public var `message`: Message?
+    }
+
+    public class HistoryMessageDeleted: Codable {
+        public init (`message`: Message?) {
+            self.`message` = `message`
+        }
+        public var `message`: Message?
+    }
+
+    public class ImapSettings: Codable {
+        public init (`autoExpunge`: Bool?, `enabled`: Bool?, `expungeBehavior`: String?, `maxFolderSize`: Int?) {
+            self.`autoExpunge` = `autoExpunge`
+            self.`enabled` = `enabled`
+            self.`expungeBehavior` = `expungeBehavior`
+            self.`maxFolderSize` = `maxFolderSize`
+        }
+        public var `autoExpunge`: Bool?
+        public var `enabled`: Bool?
+        public var `expungeBehavior`: String?
+        public var `maxFolderSize`: Int?
+    }
+
+    public class Label: Codable {
+        public init (`color`: LabelColor?, `id`: String?, `labelListVisibility`: String?, `messageListVisibility`: String?, `messagesTotal`: Int?, `messagesUnread`: Int?, `name`: String?, `threadsTotal`: Int?, `threadsUnread`: Int?, `type`: String?) {
+            self.`color` = `color`
+            self.`id` = `id`
+            self.`labelListVisibility` = `labelListVisibility`
+            self.`messageListVisibility` = `messageListVisibility`
+            self.`messagesTotal` = `messagesTotal`
+            self.`messagesUnread` = `messagesUnread`
+            self.`name` = `name`
+            self.`threadsTotal` = `threadsTotal`
+            self.`threadsUnread` = `threadsUnread`
+            self.`type` = `type`
+        }
+        public var `color`: LabelColor?
+        public var `id`: String?
+        public var `labelListVisibility`: String?
+        public var `messageListVisibility`: String?
+        public var `messagesTotal`: Int?
+        public var `messagesUnread`: Int?
+        public var `name`: String?
+        public var `threadsTotal`: Int?
+        public var `threadsUnread`: Int?
+        public var `type`: String?
+    }
+
+    public class LabelColor: Codable {
+        public init (`backgroundColor`: String?, `textColor`: String?) {
+            self.`backgroundColor` = `backgroundColor`
+            self.`textColor` = `textColor`
+        }
+        public var `backgroundColor`: String?
+        public var `textColor`: String?
+    }
+
+    public class LanguageSettings: Codable {
+        public init (`displayLanguage`: String?) {
+            self.`displayLanguage` = `displayLanguage`
+        }
+        public var `displayLanguage`: String?
+    }
+
+    public class ListDelegatesResponse: Codable {
+        public init (`delegates`: [Delegate]?) {
+            self.`delegates` = `delegates`
+        }
+        public var `delegates`: [Delegate]?
+    }
+
+    public class ListDraftsResponse: Codable {
+        public init (`drafts`: [Draft]?, `nextPageToken`: String?, `resultSizeEstimate`: Int?) {
+            self.`drafts` = `drafts`
+            self.`nextPageToken` = `nextPageToken`
+            self.`resultSizeEstimate` = `resultSizeEstimate`
+        }
+        public var `drafts`: [Draft]?
+        public var `nextPageToken`: String?
+        public var `resultSizeEstimate`: Int?
+    }
+
+    public class ListFiltersResponse: Codable {
+        public init (`filter`: [Filter]?) {
+            self.`filter` = `filter`
+        }
+        public var `filter`: [Filter]?
+    }
+
+    public class ListForwardingAddressesResponse: Codable {
+        public init (`forwardingAddresses`: [ForwardingAddress]?) {
+            self.`forwardingAddresses` = `forwardingAddresses`
+        }
+        public var `forwardingAddresses`: [ForwardingAddress]?
+    }
+
+    public class ListHistoryResponse: Codable {
+        public init (`history`: [History]?, `historyId`: String?, `nextPageToken`: String?) {
+            self.`history` = `history`
+            self.`historyId` = `historyId`
+            self.`nextPageToken` = `nextPageToken`
+        }
+        public var `history`: [History]?
+        public var `historyId`: String?
+        public var `nextPageToken`: String?
+    }
+
+    public class ListLabelsResponse: Codable {
+        public init (`labels`: [Label]?) {
+            self.`labels` = `labels`
+        }
+        public var `labels`: [Label]?
+    }
+
+    public class ListMessagesResponse: Codable {
+        public init (`messages`: [Message]?, `nextPageToken`: String?, `resultSizeEstimate`: Int?) {
+            self.`messages` = `messages`
+            self.`nextPageToken` = `nextPageToken`
+            self.`resultSizeEstimate` = `resultSizeEstimate`
+        }
+        public var `messages`: [Message]?
+        public var `nextPageToken`: String?
+        public var `resultSizeEstimate`: Int?
+    }
+
+    public class ListSendAsResponse: Codable {
+        public init (`sendAs`: [SendAs]?) {
+            self.`sendAs` = `sendAs`
+        }
+        public var `sendAs`: [SendAs]?
+    }
+
+    public class ListSmimeInfoResponse: Codable {
+        public init (`smimeInfo`: [SmimeInfo]?) {
+            self.`smimeInfo` = `smimeInfo`
+        }
+        public var `smimeInfo`: [SmimeInfo]?
+    }
+
+    public class ListThreadsResponse: Codable {
+        public init (`nextPageToken`: String?, `resultSizeEstimate`: Int?, `threads`: [Thread]?) {
+            self.`nextPageToken` = `nextPageToken`
+            self.`resultSizeEstimate` = `resultSizeEstimate`
+            self.`threads` = `threads`
+        }
+        public var `nextPageToken`: String?
+        public var `resultSizeEstimate`: Int?
+        public var `threads`: [Thread]?
+    }
+
+    public class Message: Codable {
+        public init (`historyId`: String?, `id`: String?, `internalDate`: String?, `labelIds`: [String]?, `payload`: MessagePart?, `raw`: String?, `sizeEstimate`: Int?, `snippet`: String?, `threadId`: String?) {
+            self.`historyId` = `historyId`
+            self.`id` = `id`
+            self.`internalDate` = `internalDate`
+            self.`labelIds` = `labelIds`
+            self.`payload` = `payload`
+            self.`raw` = `raw`
+            self.`sizeEstimate` = `sizeEstimate`
+            self.`snippet` = `snippet`
+            self.`threadId` = `threadId`
+        }
+        public var `historyId`: String?
+        public var `id`: String?
+        public var `internalDate`: String?
+        public var `labelIds`: [String]?
+        public var `payload`: MessagePart?
+        public var `raw`: String?
+        public var `sizeEstimate`: Int?
+        public var `snippet`: String?
+        public var `threadId`: String?
+    }
+
+    public class MessagePart: Codable {
+        public init (`body`: MessagePartBody?, `filename`: String?, `headers`: [MessagePartHeader]?, `mimeType`: String?, `partId`: String?, `parts`: [MessagePart]?) {
+            self.`body` = `body`
+            self.`filename` = `filename`
+            self.`headers` = `headers`
+            self.`mimeType` = `mimeType`
+            self.`partId` = `partId`
+            self.`parts` = `parts`
+        }
+        public var `body`: MessagePartBody?
+        public var `filename`: String?
+        public var `headers`: [MessagePartHeader]?
+        public var `mimeType`: String?
+        public var `partId`: String?
+        public var `parts`: [MessagePart]?
+    }
+
+    public class MessagePartBody: Codable {
+        public init (`attachmentId`: String?, `data`: String?, `size`: Int?) {
+            self.`attachmentId` = `attachmentId`
+            self.`data` = `data`
+            self.`size` = `size`
+        }
+        public var `attachmentId`: String?
+        public var `data`: String?
+        public var `size`: Int?
+    }
+
+    public class MessagePartHeader: Codable {
+        public init (`name`: String?, `value`: String?) {
+            self.`name` = `name`
+            self.`value` = `value`
+        }
+        public var `name`: String?
+        public var `value`: String?
+    }
+
+    public class ModifyMessageRequest: Codable {
+        public init (`addLabelIds`: [String]?, `removeLabelIds`: [String]?) {
+            self.`addLabelIds` = `addLabelIds`
+            self.`removeLabelIds` = `removeLabelIds`
+        }
+        public var `addLabelIds`: [String]?
+        public var `removeLabelIds`: [String]?
+    }
+
+    public class ModifyThreadRequest: Codable {
+        public init (`addLabelIds`: [String]?, `removeLabelIds`: [String]?) {
+            self.`addLabelIds` = `addLabelIds`
+            self.`removeLabelIds` = `removeLabelIds`
+        }
+        public var `addLabelIds`: [String]?
+        public var `removeLabelIds`: [String]?
+    }
+
+    public class PopSettings: Codable {
+        public init (`accessWindow`: String?, `disposition`: String?) {
+            self.`accessWindow` = `accessWindow`
+            self.`disposition` = `disposition`
+        }
+        public var `accessWindow`: String?
+        public var `disposition`: String?
+    }
+
+    public class Profile: Codable {
+        public init (`emailAddress`: String?, `historyId`: String?, `messagesTotal`: Int?, `threadsTotal`: Int?) {
+            self.`emailAddress` = `emailAddress`
+            self.`historyId` = `historyId`
+            self.`messagesTotal` = `messagesTotal`
+            self.`threadsTotal` = `threadsTotal`
+        }
+        public var `emailAddress`: String?
+        public var `historyId`: String?
+        public var `messagesTotal`: Int?
+        public var `threadsTotal`: Int?
+    }
+
+    public class SendAs: Codable {
+        public init (`displayName`: String?, `isDefault`: Bool?, `isPrimary`: Bool?, `replyToAddress`: String?, `sendAsEmail`: String?, `signature`: String?, `smtpMsa`: SmtpMsa?, `treatAsAlias`: Bool?, `verificationStatus`: String?) {
+            self.`displayName` = `displayName`
+            self.`isDefault` = `isDefault`
+            self.`isPrimary` = `isPrimary`
+            self.`replyToAddress` = `replyToAddress`
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`signature` = `signature`
+            self.`smtpMsa` = `smtpMsa`
+            self.`treatAsAlias` = `treatAsAlias`
+            self.`verificationStatus` = `verificationStatus`
+        }
+        public var `displayName`: String?
+        public var `isDefault`: Bool?
+        public var `isPrimary`: Bool?
+        public var `replyToAddress`: String?
+        public var `sendAsEmail`: String?
+        public var `signature`: String?
+        public var `smtpMsa`: SmtpMsa?
+        public var `treatAsAlias`: Bool?
+        public var `verificationStatus`: String?
+    }
+
+    public class SmimeInfo: Codable {
+        public init (`encryptedKeyPassword`: String?, `expiration`: String?, `id`: String?, `isDefault`: Bool?, `issuerCn`: String?, `pem`: String?, `pkcs12`: String?) {
+            self.`encryptedKeyPassword` = `encryptedKeyPassword`
+            self.`expiration` = `expiration`
+            self.`id` = `id`
+            self.`isDefault` = `isDefault`
+            self.`issuerCn` = `issuerCn`
+            self.`pem` = `pem`
+            self.`pkcs12` = `pkcs12`
+        }
+        public var `encryptedKeyPassword`: String?
+        public var `expiration`: String?
+        public var `id`: String?
+        public var `isDefault`: Bool?
+        public var `issuerCn`: String?
+        public var `pem`: String?
+        public var `pkcs12`: String?
+    }
+
+    public class SmtpMsa: Codable {
+        public init (`host`: String?, `password`: String?, `port`: Int?, `securityMode`: String?, `username`: String?) {
+            self.`host` = `host`
+            self.`password` = `password`
+            self.`port` = `port`
+            self.`securityMode` = `securityMode`
+            self.`username` = `username`
+        }
+        public var `host`: String?
+        public var `password`: String?
+        public var `port`: Int?
+        public var `securityMode`: String?
+        public var `username`: String?
+    }
+
+    public class Thread: Codable {
+        public init (`historyId`: String?, `id`: String?, `messages`: [Message]?, `snippet`: String?) {
+            self.`historyId` = `historyId`
+            self.`id` = `id`
+            self.`messages` = `messages`
+            self.`snippet` = `snippet`
+        }
+        public var `historyId`: String?
+        public var `id`: String?
+        public var `messages`: [Message]?
+        public var `snippet`: String?
+    }
+
+    public class VacationSettings: Codable {
+        public init (`enableAutoReply`: Bool?, `endTime`: String?, `responseBodyHtml`: String?, `responseBodyPlainText`: String?, `responseSubject`: String?, `restrictToContacts`: Bool?, `restrictToDomain`: Bool?, `startTime`: String?) {
+            self.`enableAutoReply` = `enableAutoReply`
+            self.`endTime` = `endTime`
+            self.`responseBodyHtml` = `responseBodyHtml`
+            self.`responseBodyPlainText` = `responseBodyPlainText`
+            self.`responseSubject` = `responseSubject`
+            self.`restrictToContacts` = `restrictToContacts`
+            self.`restrictToDomain` = `restrictToDomain`
+            self.`startTime` = `startTime`
+        }
+        public var `enableAutoReply`: Bool?
+        public var `endTime`: String?
+        public var `responseBodyHtml`: String?
+        public var `responseBodyPlainText`: String?
+        public var `responseSubject`: String?
+        public var `restrictToContacts`: Bool?
+        public var `restrictToDomain`: Bool?
+        public var `startTime`: String?
+    }
+
+    public class WatchRequest: Codable {
+        public init (`labelFilterAction`: String?, `labelIds`: [String]?, `topicName`: String?) {
+            self.`labelFilterAction` = `labelFilterAction`
+            self.`labelIds` = `labelIds`
+            self.`topicName` = `topicName`
+        }
+        public var `labelFilterAction`: String?
+        public var `labelIds`: [String]?
+        public var `topicName`: String?
+    }
+
+    public class WatchResponse: Codable {
+        public init (`expiration`: String?, `historyId`: String?) {
+            self.`expiration` = `expiration`
+            self.`historyId` = `historyId`
+        }
+        public var `expiration`: String?
+        public var `historyId`: String?
+    }
+
+
+
+
+    public class usersgetProfileParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_getProfile (
+        parameters: usersgetProfileParameters,
+        completion: @escaping (Profile?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/profile",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class usersstopParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_stop (
+        parameters: usersstopParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/stop",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class userswatchParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_watch (
+        request: WatchRequest,
+        parameters: userswatchParameters,
+        completion: @escaping (WatchResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/watch",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_draftscreateParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_drafts_create (
+        request: Draft,
+        parameters: users_draftscreateParameters,
+        completion: @escaping (Draft?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/drafts",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_draftsdeleteParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_drafts_delete (
+        parameters: users_draftsdeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "DELETE",
+                path: "gmail/v1/users/{userId}/drafts/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_draftsgetParameters: Parameterizable {
+        public init (`format`: String?, `id`: String?, `userId`: String?) {
+            self.`format` = `format`
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `format`: String?
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            ["format"]
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_drafts_get (
+        parameters: users_draftsgetParameters,
+        completion: @escaping (Draft?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/drafts/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_draftslistParameters: Parameterizable {
+        public init (`includeSpamTrash`: Bool?, `maxResults`: Int?, `pageToken`: String?, `q`: String?, `userId`: String?) {
+            self.`includeSpamTrash` = `includeSpamTrash`
+            self.`maxResults` = `maxResults`
+            self.`pageToken` = `pageToken`
+            self.`q` = `q`
+            self.`userId` = `userId`
+        }
+
+        public var `includeSpamTrash`: Bool?
+        public var `maxResults`: Int?
+        public var `pageToken`: String?
+        public var `q`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            ["includeSpamTrash","maxResults","pageToken","q"]
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_drafts_list (
+        parameters: users_draftslistParameters,
+        completion: @escaping (ListDraftsResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/drafts",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_draftssendParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_drafts_send (
+        request: Draft,
+        parameters: users_draftssendParameters,
+        completion: @escaping (Message?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/drafts/send",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_draftsupdateParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_drafts_update (
+        request: Draft,
+        parameters: users_draftsupdateParameters,
+        completion: @escaping (Draft?, Error?) -> ()) throws {
+            try perform(
+                method: "PUT",
+                path: "gmail/v1/users/{userId}/drafts/{id}",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_historylistParameters: Parameterizable {
+        public init (`historyTypes`: String?, `labelId`: String?, `maxResults`: Int?, `pageToken`: String?, `startHistoryId`: String?, `userId`: String?) {
+            self.`historyTypes` = `historyTypes`
+            self.`labelId` = `labelId`
+            self.`maxResults` = `maxResults`
+            self.`pageToken` = `pageToken`
+            self.`startHistoryId` = `startHistoryId`
+            self.`userId` = `userId`
+        }
+
+        public var `historyTypes`: String?
+        public var `labelId`: String?
+        public var `maxResults`: Int?
+        public var `pageToken`: String?
+        public var `startHistoryId`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            ["historyTypes","labelId","maxResults","pageToken","startHistoryId"]
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_history_list (
+        parameters: users_historylistParameters,
+        completion: @escaping (ListHistoryResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/history",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_labelscreateParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_labels_create (
+        request: Label,
+        parameters: users_labelscreateParameters,
+        completion: @escaping (Label?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/labels",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_labelsdeleteParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_labels_delete (
+        parameters: users_labelsdeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "DELETE",
+                path: "gmail/v1/users/{userId}/labels/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_labelsgetParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_labels_get (
+        parameters: users_labelsgetParameters,
+        completion: @escaping (Label?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/labels/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_labelslistParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_labels_list (
+        parameters: users_labelslistParameters,
+        completion: @escaping (ListLabelsResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/labels",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_labelspatchParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_labels_patch (
+        request: Label,
+        parameters: users_labelspatchParameters,
+        completion: @escaping (Label?, Error?) -> ()) throws {
+            try perform(
+                method: "PATCH",
+                path: "gmail/v1/users/{userId}/labels/{id}",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_labelsupdateParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_labels_update (
+        request: Label,
+        parameters: users_labelsupdateParameters,
+        completion: @escaping (Label?, Error?) -> ()) throws {
+            try perform(
+                method: "PUT",
+                path: "gmail/v1/users/{userId}/labels/{id}",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagesbatchDeleteParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_messages_batchDelete (
+        request: BatchDeleteMessagesRequest,
+        parameters: users_messagesbatchDeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/messages/batchDelete",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagesbatchModifyParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_messages_batchModify (
+        request: BatchModifyMessagesRequest,
+        parameters: users_messagesbatchModifyParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/messages/batchModify",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagesdeleteParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_messages_delete (
+        parameters: users_messagesdeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "DELETE",
+                path: "gmail/v1/users/{userId}/messages/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagesgetParameters: Parameterizable {
+        public init (`format`: String?, `id`: String?, `metadataHeaders`: String?, `userId`: String?) {
+            self.`format` = `format`
+            self.`id` = `id`
+            self.`metadataHeaders` = `metadataHeaders`
+            self.`userId` = `userId`
+        }
+
+        public var `format`: String?
+        public var `id`: String?
+        public var `metadataHeaders`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            ["format","metadataHeaders"]
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_messages_get (
+        parameters: users_messagesgetParameters,
+        completion: @escaping (Message?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/messages/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagesimportParameters: Parameterizable {
+        public init (`deleted`: Bool?, `internalDateSource`: String?, `neverMarkSpam`: Bool?, `processForCalendar`: Bool?, `userId`: String?) {
+            self.`deleted` = `deleted`
+            self.`internalDateSource` = `internalDateSource`
+            self.`neverMarkSpam` = `neverMarkSpam`
+            self.`processForCalendar` = `processForCalendar`
+            self.`userId` = `userId`
+        }
+
+        public var `deleted`: Bool?
+        public var `internalDateSource`: String?
+        public var `neverMarkSpam`: Bool?
+        public var `processForCalendar`: Bool?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            ["deleted","internalDateSource","neverMarkSpam","processForCalendar"]
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_messages_import (
+        request: Message,
+        parameters: users_messagesimportParameters,
+        completion: @escaping (Message?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/messages/import",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagesinsertParameters: Parameterizable {
+        public init (`deleted`: Bool?, `internalDateSource`: String?, `userId`: String?) {
+            self.`deleted` = `deleted`
+            self.`internalDateSource` = `internalDateSource`
+            self.`userId` = `userId`
+        }
+
+        public var `deleted`: Bool?
+        public var `internalDateSource`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            ["deleted","internalDateSource"]
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_messages_insert (
+        request: Message,
+        parameters: users_messagesinsertParameters,
+        completion: @escaping (Message?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/messages",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messageslistParameters: Parameterizable {
+        public init (`includeSpamTrash`: Bool?, `labelIds`: String?, `maxResults`: Int?, `pageToken`: String?, `q`: String?, `userId`: String?) {
+            self.`includeSpamTrash` = `includeSpamTrash`
+            self.`labelIds` = `labelIds`
+            self.`maxResults` = `maxResults`
+            self.`pageToken` = `pageToken`
+            self.`q` = `q`
+            self.`userId` = `userId`
+        }
+
+        public var `includeSpamTrash`: Bool?
+        public var `labelIds`: String?
+        public var `maxResults`: Int?
+        public var `pageToken`: String?
+        public var `q`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            ["includeSpamTrash","labelIds","maxResults","pageToken","q"]
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_messages_list (
+        parameters: users_messageslistParameters,
+        completion: @escaping (ListMessagesResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/messages",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagesmodifyParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_messages_modify (
+        request: ModifyMessageRequest,
+        parameters: users_messagesmodifyParameters,
+        completion: @escaping (Message?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/messages/{id}/modify",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagessendParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_messages_send (
+        request: Message,
+        parameters: users_messagessendParameters,
+        completion: @escaping (Message?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/messages/send",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagestrashParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_messages_trash (
+        parameters: users_messagestrashParameters,
+        completion: @escaping (Message?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/messages/{id}/trash",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messagesuntrashParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_messages_untrash (
+        parameters: users_messagesuntrashParameters,
+        completion: @escaping (Message?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/messages/{id}/untrash",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_messages_attachmentsgetParameters: Parameterizable {
+        public init (`id`: String?, `messageId`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`messageId` = `messageId`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `messageId`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","messageId","userId"]
+        }
+    }
+
+    public func users_messages_attachments_get (
+        parameters: users_messages_attachmentsgetParameters,
+        completion: @escaping (MessagePartBody?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/messages/{messageId}/attachments/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsgetAutoForwardingParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_getAutoForwarding (
+        parameters: users_settingsgetAutoForwardingParameters,
+        completion: @escaping (AutoForwarding?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/autoForwarding",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsgetImapParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_getImap (
+        parameters: users_settingsgetImapParameters,
+        completion: @escaping (ImapSettings?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/imap",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsgetLanguageParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_getLanguage (
+        parameters: users_settingsgetLanguageParameters,
+        completion: @escaping (LanguageSettings?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/language",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsgetPopParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_getPop (
+        parameters: users_settingsgetPopParameters,
+        completion: @escaping (PopSettings?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/pop",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsgetVacationParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_getVacation (
+        parameters: users_settingsgetVacationParameters,
+        completion: @escaping (VacationSettings?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/vacation",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsupdateAutoForwardingParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_updateAutoForwarding (
+        request: AutoForwarding,
+        parameters: users_settingsupdateAutoForwardingParameters,
+        completion: @escaping (AutoForwarding?, Error?) -> ()) throws {
+            try perform(
+                method: "PUT",
+                path: "gmail/v1/users/{userId}/settings/autoForwarding",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsupdateImapParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_updateImap (
+        request: ImapSettings,
+        parameters: users_settingsupdateImapParameters,
+        completion: @escaping (ImapSettings?, Error?) -> ()) throws {
+            try perform(
+                method: "PUT",
+                path: "gmail/v1/users/{userId}/settings/imap",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsupdateLanguageParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_updateLanguage (
+        request: LanguageSettings,
+        parameters: users_settingsupdateLanguageParameters,
+        completion: @escaping (LanguageSettings?, Error?) -> ()) throws {
+            try perform(
+                method: "PUT",
+                path: "gmail/v1/users/{userId}/settings/language",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsupdatePopParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_updatePop (
+        request: PopSettings,
+        parameters: users_settingsupdatePopParameters,
+        completion: @escaping (PopSettings?, Error?) -> ()) throws {
+            try perform(
+                method: "PUT",
+                path: "gmail/v1/users/{userId}/settings/pop",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settingsupdateVacationParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_updateVacation (
+        request: VacationSettings,
+        parameters: users_settingsupdateVacationParameters,
+        completion: @escaping (VacationSettings?, Error?) -> ()) throws {
+            try perform(
+                method: "PUT",
+                path: "gmail/v1/users/{userId}/settings/vacation",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_delegatescreateParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_delegates_create (
+        request: Delegate,
+        parameters: users_settings_delegatescreateParameters,
+        completion: @escaping (Delegate?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/settings/delegates",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_delegatesdeleteParameters: Parameterizable {
+        public init (`delegateEmail`: String?, `userId`: String?) {
+            self.`delegateEmail` = `delegateEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `delegateEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["delegateEmail","userId"]
+        }
+    }
+
+    public func users_settings_delegates_delete (
+        parameters: users_settings_delegatesdeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "DELETE",
+                path: "gmail/v1/users/{userId}/settings/delegates/{delegateEmail}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_delegatesgetParameters: Parameterizable {
+        public init (`delegateEmail`: String?, `userId`: String?) {
+            self.`delegateEmail` = `delegateEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `delegateEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["delegateEmail","userId"]
+        }
+    }
+
+    public func users_settings_delegates_get (
+        parameters: users_settings_delegatesgetParameters,
+        completion: @escaping (Delegate?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/delegates/{delegateEmail}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_delegateslistParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_delegates_list (
+        parameters: users_settings_delegateslistParameters,
+        completion: @escaping (ListDelegatesResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/delegates",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_filterscreateParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_filters_create (
+        request: Filter,
+        parameters: users_settings_filterscreateParameters,
+        completion: @escaping (Filter?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/settings/filters",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_filtersdeleteParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_settings_filters_delete (
+        parameters: users_settings_filtersdeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "DELETE",
+                path: "gmail/v1/users/{userId}/settings/filters/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_filtersgetParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_settings_filters_get (
+        parameters: users_settings_filtersgetParameters,
+        completion: @escaping (Filter?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/filters/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_filterslistParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_filters_list (
+        parameters: users_settings_filterslistParameters,
+        completion: @escaping (ListFiltersResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/filters",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_forwardingAddressescreateParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_forwardingAddresses_create (
+        request: ForwardingAddress,
+        parameters: users_settings_forwardingAddressescreateParameters,
+        completion: @escaping (ForwardingAddress?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/settings/forwardingAddresses",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_forwardingAddressesdeleteParameters: Parameterizable {
+        public init (`forwardingEmail`: String?, `userId`: String?) {
+            self.`forwardingEmail` = `forwardingEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `forwardingEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["forwardingEmail","userId"]
+        }
+    }
+
+    public func users_settings_forwardingAddresses_delete (
+        parameters: users_settings_forwardingAddressesdeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "DELETE",
+                path: "gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_forwardingAddressesgetParameters: Parameterizable {
+        public init (`forwardingEmail`: String?, `userId`: String?) {
+            self.`forwardingEmail` = `forwardingEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `forwardingEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["forwardingEmail","userId"]
+        }
+    }
+
+    public func users_settings_forwardingAddresses_get (
+        parameters: users_settings_forwardingAddressesgetParameters,
+        completion: @escaping (ForwardingAddress?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_forwardingAddresseslistParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_forwardingAddresses_list (
+        parameters: users_settings_forwardingAddresseslistParameters,
+        completion: @escaping (ListForwardingAddressesResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/forwardingAddresses",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAscreateParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_sendAs_create (
+        request: SendAs,
+        parameters: users_settings_sendAscreateParameters,
+        completion: @escaping (SendAs?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/settings/sendAs",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAsdeleteParameters: Parameterizable {
+        public init (`sendAsEmail`: String?, `userId`: String?) {
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_delete (
+        parameters: users_settings_sendAsdeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "DELETE",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAsgetParameters: Parameterizable {
+        public init (`sendAsEmail`: String?, `userId`: String?) {
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_get (
+        parameters: users_settings_sendAsgetParameters,
+        completion: @escaping (SendAs?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAslistParameters: Parameterizable {
+        public init (`userId`: String?) {
+            self.`userId` = `userId`
+        }
+
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_settings_sendAs_list (
+        parameters: users_settings_sendAslistParameters,
+        completion: @escaping (ListSendAsResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/sendAs",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAspatchParameters: Parameterizable {
+        public init (`sendAsEmail`: String?, `userId`: String?) {
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_patch (
+        request: SendAs,
+        parameters: users_settings_sendAspatchParameters,
+        completion: @escaping (SendAs?, Error?) -> ()) throws {
+            try perform(
+                method: "PATCH",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAsupdateParameters: Parameterizable {
+        public init (`sendAsEmail`: String?, `userId`: String?) {
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_update (
+        request: SendAs,
+        parameters: users_settings_sendAsupdateParameters,
+        completion: @escaping (SendAs?, Error?) -> ()) throws {
+            try perform(
+                method: "PUT",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAsverifyParameters: Parameterizable {
+        public init (`sendAsEmail`: String?, `userId`: String?) {
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_verify (
+        parameters: users_settings_sendAsverifyParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/verify",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAs_smimeInfodeleteParameters: Parameterizable {
+        public init (`id`: String?, `sendAsEmail`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_smimeInfo_delete (
+        parameters: users_settings_sendAs_smimeInfodeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "DELETE",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAs_smimeInfogetParameters: Parameterizable {
+        public init (`id`: String?, `sendAsEmail`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_smimeInfo_get (
+        parameters: users_settings_sendAs_smimeInfogetParameters,
+        completion: @escaping (SmimeInfo?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAs_smimeInfoinsertParameters: Parameterizable {
+        public init (`sendAsEmail`: String?, `userId`: String?) {
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_smimeInfo_insert (
+        request: SmimeInfo,
+        parameters: users_settings_sendAs_smimeInfoinsertParameters,
+        completion: @escaping (SmimeInfo?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAs_smimeInfolistParameters: Parameterizable {
+        public init (`sendAsEmail`: String?, `userId`: String?) {
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_smimeInfo_list (
+        parameters: users_settings_sendAs_smimeInfolistParameters,
+        completion: @escaping (ListSmimeInfoResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_settings_sendAs_smimeInfosetDefaultParameters: Parameterizable {
+        public init (`id`: String?, `sendAsEmail`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`sendAsEmail` = `sendAsEmail`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `sendAsEmail`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","sendAsEmail","userId"]
+        }
+    }
+
+    public func users_settings_sendAs_smimeInfo_setDefault (
+        parameters: users_settings_sendAs_smimeInfosetDefaultParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_threadsdeleteParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_threads_delete (
+        parameters: users_threadsdeleteParameters,
+        completion: @escaping (Error?) -> ()) throws {
+            try perform(
+                method: "DELETE",
+                path: "gmail/v1/users/{userId}/threads/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_threadsgetParameters: Parameterizable {
+        public init (`format`: String?, `id`: String?, `metadataHeaders`: String?, `userId`: String?) {
+            self.`format` = `format`
+            self.`id` = `id`
+            self.`metadataHeaders` = `metadataHeaders`
+            self.`userId` = `userId`
+        }
+
+        public var `format`: String?
+        public var `id`: String?
+        public var `metadataHeaders`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            ["format","metadataHeaders"]
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_threads_get (
+        parameters: users_threadsgetParameters,
+        completion: @escaping (Thread?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/threads/{id}",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_threadslistParameters: Parameterizable {
+        public init (`includeSpamTrash`: Bool?, `labelIds`: String?, `maxResults`: Int?, `pageToken`: String?, `q`: String?, `userId`: String?) {
+            self.`includeSpamTrash` = `includeSpamTrash`
+            self.`labelIds` = `labelIds`
+            self.`maxResults` = `maxResults`
+            self.`pageToken` = `pageToken`
+            self.`q` = `q`
+            self.`userId` = `userId`
+        }
+
+        public var `includeSpamTrash`: Bool?
+        public var `labelIds`: String?
+        public var `maxResults`: Int?
+        public var `pageToken`: String?
+        public var `q`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            ["includeSpamTrash","labelIds","maxResults","pageToken","q"]
+        }
+        public func pathParameters() -> [String] {
+            ["userId"]
+        }
+    }
+
+    public func users_threads_list (
+        parameters: users_threadslistParameters,
+        completion: @escaping (ListThreadsResponse?, Error?) -> ()) throws {
+            try perform(
+                method: "GET",
+                path: "gmail/v1/users/{userId}/threads",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_threadsmodifyParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_threads_modify (
+        request: ModifyThreadRequest,
+        parameters: users_threadsmodifyParameters,
+        completion: @escaping (Thread?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/threads/{id}/modify",
+                request: request,
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_threadstrashParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_threads_trash (
+        parameters: users_threadstrashParameters,
+        completion: @escaping (Thread?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/threads/{id}/trash",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+    public class users_threadsuntrashParameters: Parameterizable {
+        public init (`id`: String?, `userId`: String?) {
+            self.`id` = `id`
+            self.`userId` = `userId`
+        }
+
+        public var `id`: String?
+        public var `userId`: String?
+
+        public func queryParameters() -> [String] {
+            []
+        }
+        public func pathParameters() -> [String] {
+            ["id","userId"]
+        }
+    }
+
+    public func users_threads_untrash (
+        parameters: users_threadsuntrashParameters,
+        completion: @escaping (Thread?, Error?) -> ()) throws {
+            try perform(
+                method: "POST",
+                path: "gmail/v1/users/{userId}/threads/{id}/untrash",
+                parameters: parameters,
+                completion: completion)
+    }
+
+
+}

--- a/Sources/OAuth2/AuthError.swift
+++ b/Sources/OAuth2/AuthError.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 import Foundation
 
-enum AuthError: Error {
+public enum AuthError: Error {
   case unknownError
+  case webSession(inner: Error)
 }

--- a/Sources/OAuth2/Code.swift
+++ b/Sources/OAuth2/Code.swift
@@ -11,7 +11,24 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+import Dispatch
 import Foundation
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+import NIOHTTP1
+import TinyHTTPServer
+
+// For the browser and native flows, an oauth2 authorization code must be
+// exchanged for a live token by the user's agent/client.
+
+protocol CodeExchangeInfo {
+  var accessTokenURL: String { get }
+  var clientID: String { get }
+  var clientSecret: String { get }
+  var redirectURI: String { get }
+}
 
 class Code {
   var code: String?
@@ -32,6 +49,58 @@ class Code {
           break
         }
       }
+    }
+  }
+
+  func exchange(info: CodeExchangeInfo) throws -> Token {
+    let sem = DispatchSemaphore(value: 0)
+    let parameters = [
+      "client_id": info.clientID, // some providers require the client id and secret in the method call
+      "client_secret": info.clientSecret,
+      "grant_type": "authorization_code",
+      "code": self.code!,
+      "redirect_uri": info.redirectURI,
+    ]
+    let token = info.clientID + ":" + info.clientSecret
+    // some providers require the client id and secret in the authorization header
+    let authorization = "Basic " + String(data: token.data(using: .utf8)!.base64EncodedData(), encoding: .utf8)!
+    var responseData: Data?
+    var contentType: String?
+    Connection.performRequest(
+      method: "POST",
+      urlString: info.accessTokenURL,
+      parameters: parameters,
+      body: nil,
+      authorization: authorization
+    ) { data, response, _ in
+      if let response = response as? HTTPURLResponse {
+        for (k, v) in response.allHeaderFields {
+          // Explicitly-lowercasing seems like it should be unnecessary,
+          // but some services returned "Content-Type" and others sent "content-type".
+          if (k as! String).lowercased() == "content-type" {
+            contentType = v as? String
+          }
+        }
+      }
+      responseData = data
+      sem.signal()
+    }
+    _ = sem.wait(timeout: DispatchTime.distantFuture)
+    if let contentType = contentType, contentType.contains("application/json") {
+      let decoder = JSONDecoder()
+      let token = try! decoder.decode(Token.self, from: responseData!)
+      return token
+    } else { // assume "application/x-www-form-urlencoded"
+      guard let responseData = responseData else {
+        throw AuthError.unknownError
+      }
+      guard let queryParameters = String(data: responseData, encoding: .utf8) else {
+        throw AuthError.unknownError
+      }
+      guard let urlComponents = URLComponents(string: "http://example.com?" + queryParameters) else {
+        throw AuthError.unknownError
+      }
+      return Token(urlComponents: urlComponents)
     }
   }
 }

--- a/Sources/OAuth2/PlatformNativeTokenProvider.swift
+++ b/Sources/OAuth2/PlatformNativeTokenProvider.swift
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC. All Rights Reserved.
+// Copyright 2021 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,39 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if os(macOS) || os(iOS)
 import Dispatch
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
-import NIOHTTP1
-import TinyHTTPServer
+import AuthenticationServices
 
-struct Credentials: Codable, CodeExchangeInfo {
+struct NativeCredentials: Codable, CodeExchangeInfo {
   let clientID: String
-  let clientSecret: String
   let authorizeURL: String
   let accessTokenURL: String
-  let callback: String
+  let callbackScheme: String
   enum CodingKeys: String, CodingKey {
     case clientID = "client_id"
-    case clientSecret = "client_secret"
     case authorizeURL = "authorize_url"
     case accessTokenURL = "access_token_url"
-    case callback
+    case callbackScheme = "callback_scheme"
   }
   var redirectURI: String {
-    "http://localhost:8080" + self.callback
+    callbackScheme + ":/google/callback"
+  }
+  var clientSecret: String {
+    ""
   }
 }
 
-public class BrowserTokenProvider: TokenProvider {
-  private var credentials: Credentials
-  private var code: Code?
+@available(macOS 10.15.4, iOS 13.4, *)
+public class PlatformNativeTokenProvider: TokenProvider {
+  private var credentials: NativeCredentials
+  private var session: ASWebAuthenticationSession?
   public var token: Token?
 
-  private var sem: DispatchSemaphore?
-
+  // for parity with BrowserTokenProvider
   public convenience init?(credentials: String, token tokenfile: String) {
     let path = ProcessInfo.processInfo.environment["HOME"]!
       + "/.credentials/" + credentials
@@ -59,7 +57,7 @@ public class BrowserTokenProvider: TokenProvider {
 
   public init?(credentials: Data, token tokenfile: String) {
     let decoder = JSONDecoder()
-    guard let credentials = try? decoder.decode(Credentials.self,
+    guard let credentials = try? decoder.decode(NativeCredentials.self,
                                                 from: credentials)
     else {
       print("Error reading credentials")
@@ -88,37 +86,15 @@ public class BrowserTokenProvider: TokenProvider {
     }
   }
 
-  // StartServer starts a web server that listens on http://localhost:8080.
-  // The webserver waits for an oauth code in the three-legged auth flow.
-  private func startServer(sem: DispatchSemaphore) throws {
-    self.sem = sem
-
-    try TinyHTTPServer().start { server, request -> (String, HTTPResponseStatus) in
-      if request.uri.unicodeScalars.starts(with: self.credentials.callback.unicodeScalars) {
-        server.stop()
-        if let urlComponents = URLComponents(string: request.uri) {
-          self.code = Code(urlComponents: urlComponents)
-          DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
-            self.sem?.signal()
-          }
-          return ("success! Token received.\n", .ok)
-        } else {
-          return ("failed to get token.\n", .ok)
-        }
-      } else {
-        return ("not found\n", .notFound)
-      }
-    }
-  }
-
-  @available(iOS 10.0, tvOS 10.0, *)
-  public func signIn(scopes: [String]) throws {
-    let sem = DispatchSemaphore(value: 0)
-    try startServer(sem: sem)
-
+  // The presentation context provides a reference to a UIWindow that the auth
+  // framework uese to display the confirmation modal and sign in controller.
+  public func signIn(
+    scopes: [String],
+    context: ASWebAuthenticationPresentationContextProviding,
+    completion: @escaping (Token?, AuthError?) -> Void
+  ) {
     let state = UUID().uuidString
     let scope = scopes.joined(separator: " ")
-
     var urlComponents = URLComponents(string: credentials.authorizeURL)!
     urlComponents.queryItems = [
       URLQueryItem(name: "client_id", value: credentials.clientID),
@@ -128,12 +104,55 @@ public class BrowserTokenProvider: TokenProvider {
       URLQueryItem(name: "scope", value: scope),
       URLQueryItem(name: "show_dialog", value: "false"),
     ]
-    openURL(urlComponents.url!)
-    _ = sem.wait(timeout: DispatchTime.distantFuture)
-    token = try code!.exchange(info: credentials)
+
+    let session = ASWebAuthenticationSession(
+      url: urlComponents.url!,
+      callbackURLScheme: credentials.callbackScheme
+    ) { url, err in
+      defer { self.session = nil }
+      if let e = err {
+        completion(nil, .webSession(inner: e))
+        return
+      }
+      guard let u = url else {
+        // If err is nil, url should not be, and vice versa.
+        completion(nil, .unknownError)
+        return
+      }
+      let code = Code(urlComponents: URLComponents(string: u.absoluteString)!)
+      do {
+        self.token = try code.exchange(info: self.credentials)
+        completion(self.token!, nil)
+      } catch let ae as AuthError {
+        completion(nil, ae)
+      } catch {
+        completion(nil, .unknownError)
+      }
+    }
+
+    session.presentationContextProvider = context
+    if !session.canStart {
+      // This happens if the context provider is not set, or if the session has
+      // already been started. We enforce correct usage so ignore.
+      return
+    }
+    let success = session.start()
+    if !success {
+      // This doesn't happen unless the context is not set, disappears (it's a
+      // weak ref internally), or the session was previously started, ignore.
+      return
+    }
+    self.session = session
+  }
+
+  // Canceling the session dismisses the view controller if it is showing.
+  public func cancelSignIn() {
+    session?.cancel()
+    self.session = nil
   }
 
   public func withToken(_ callback: @escaping (Token?, Error?) -> Void) throws {
     callback(token, nil)
   }
 }
+#endif


### PR DESCRIPTION
Add a platform native token provider that uses the authentication services framework to do oauth2. Here it is in action:

https://user-images.githubusercontent.com/547926/142566963-93a2e752-b10e-4197-b87a-4b12bb55b52e.mov

The first run is the browser provider. The second run is the native flow. 

Obviously this pr needs work before merging (prints, copy/paste cleanup, fixup commits, etc.) but I'm opening it now to see if there's any interest.

