### PR TITLE
adding a short circuit when an unexpired token exists in the provider

### DIFF
--- a/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
+++ b/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
@@ -73,6 +73,13 @@ public class ServiceAccountTokenProvider : TokenProvider {
   }
   
   public func withToken(_ callback:@escaping (Token?, Error?) -> Void) throws {
+
+    // leave spare at least one second :)
+    if let token = token, token.timeToExpiry() > 1 {
+      callback(token, nil)
+      return
+    }
+  
     let iat = Date()
     let exp = iat.addingTimeInterval(3600)
     let jwtClaimSet = JWTClaimSet(Issuer:credentials.ClientEmail,
@@ -100,6 +107,8 @@ public class ServiceAccountTokenProvider : TokenProvider {
       let decoder = JSONDecoder()
       if let data = data,
         let token = try? decoder.decode(Token.self, from: data) {
+        self.token = token
+        self.token?.CreationTime = Date()
         callback(token, error)
       } else {
         callback(nil, error)

--- a/Sources/OAuth2/Token.swift
+++ b/Sources/OAuth2/Token.swift
@@ -35,6 +35,19 @@ public struct Token : Codable {
     try data.write(to: URL(fileURLWithPath: filename))
   }
   
+  public func isExpired() -> Bool {
+    return timeToExpiry() > 0
+  }
+
+  
+  public func timeToExpiry() -> TimeInterval {
+    guard let expiresIn = ExpiresIn, let creationTime = CreationTime else {
+      return 0.0 // if we dont know when it expires, assume its expired
+    }
+    let expireDate = creationTime.addingTimeInterval(TimeInterval(expiresIn))
+    return expireDate.timeIntervalSinceNow
+  }
+  
   public init(accessToken: String) {
     self.AccessToken = accessToken
   }


### PR DESCRIPTION
Change in response to issue #56 

when a valid unexpired token is still held by the ServiceAccountTokenProvider, return it.

Note that this may create multiple tokens created on subsequent calls between first request and first completion, but this should be no worse than before as it would request on every call.