### PR TITLE
oauth2: add browser and native token refresh support

### DIFF
--- a/Examples/GAuth-Apple/Shared/ContentView.swift
+++ b/Examples/GAuth-Apple/Shared/ContentView.swift
@@ -42,12 +42,18 @@ struct ContentView: View {
         Text("Login Native")
       }
       Spacer()
-      Button {
-        token_cache_clear()
-      } label: {
-        Text("Clear Token Cache")
+      HStack {
+        Button {
+          token_refresh()
+        } label: {
+          Text("Refresh Token")
+        }
+        Button {
+          token_cache_clear()
+        } label: {
+          Text("Clear Token Cache")
+        }
       }
-
     }
     .padding()
     .background(WindowAccessor(window: $window))

--- a/Examples/GAuth-Apple/Shared/ContentView.swift
+++ b/Examples/GAuth-Apple/Shared/ContentView.swift
@@ -24,36 +24,59 @@ struct ContentView: View {
       HStack { Spacer().frame(maxWidth: .infinity) }
       Text("GAuth Example")
       Divider()
-      Spacer()
 
-      Button(action: {
-        oauth2_browser()
-      }) {
-        Text("Login Browser")
+      VStack {
+        Text("Browser")
+        Button {
+          oauth2_browser()
+        } label: {
+          Text("Login")
+        }
+        Button {
+          token_refresh(.native)
+        } label: {
+          Text("Refresh Token")
+        }
+        Button {
+          query_gmail(.native)
+        } label: {
+          Text("Query Gmail")
+        }
+        Button {
+          token_cache_clear(.native)
+        } label: {
+          Text("Clear Token Cache")
+        }
       }
 
       Divider()
         .padding()
         .frame(maxWidth: 120)
 
-      Button(action: {
-        oauth2_native(anchor: window!)
-      }) {
-        Text("Login Native")
-      }
-      Spacer()
-      HStack {
+      VStack {
+        Text("Native")
         Button {
-          token_refresh()
+          oauth2_native(anchor: window!)
+        } label: {
+          Text("Login")
+        }
+        Button {
+          token_refresh(.native)
         } label: {
           Text("Refresh Token")
         }
         Button {
-          token_cache_clear()
+          query_gmail(.native)
+        } label: {
+          Text("Query Gmail")
+        }
+        Button {
+          token_cache_clear(.native)
         } label: {
           Text("Clear Token Cache")
         }
       }
+      Spacer()
     }
     .padding()
     .background(WindowAccessor(window: $window))

--- a/Examples/GAuth-Apple/Shared/GAuth.swift
+++ b/Examples/GAuth-Apple/Shared/GAuth.swift
@@ -169,3 +169,20 @@ func token_cache_clear() {
     try? FileManager.default.removeItem(at: url)
   }
 }
+
+func token_refresh() {
+  let data = try! Data(contentsOf: token_cache_url()!)
+  let cdata = creds_native.data(using: .utf8)!
+  let creds = try! JSONDecoder().decode(NativeCredentials.self, from: cdata)
+  let newToken = try! Refresh(token: data)!.exchange(info: creds)
+  print(newToken)
+
+  // now to save... ...
+  // clearly this is not good yet
+  // we need refreshToken to be dispatched from the provider itself.
+  // ..will rework
+  let tfile = token_cache_url()?.path ?? ""
+  let tp = PlatformNativeTokenProvider(credentials: cdata, token: tfile)!
+  tp.token = newToken
+  try! tp.saveToken(tfile)
+}

--- a/Sources/OAuth2/AuthError.swift
+++ b/Sources/OAuth2/AuthError.swift
@@ -14,6 +14,7 @@
 import Foundation
 
 public enum AuthError: Error {
+  case noRefreshToken
   case unknownError
   case webSession(inner: Error)
 }

--- a/Sources/OAuth2/BrowserTokenProvider.swift
+++ b/Sources/OAuth2/BrowserTokenProvider.swift
@@ -20,7 +20,7 @@ import Foundation
 import NIOHTTP1
 import TinyHTTPServer
 
-struct Credentials: Codable, CodeExchangeInfo {
+struct Credentials: Codable, CodeExchangeInfo, RefreshExchangeInfo {
   let clientID: String
   let clientSecret: String
   let authorizeURL: String
@@ -85,6 +85,13 @@ public class BrowserTokenProvider: TokenProvider {
   public func saveToken(_ filename: String) throws {
     if let token = token {
       try token.save(filename)
+    }
+  }
+
+  public func refreshToken(_ filename: String) throws {
+    if let token = token, token.isExpired() {
+      self.token = try Refresh(token: token).exchange(info: credentials)
+      try saveToken(filename)
     }
   }
 

--- a/Sources/OAuth2/PlatformNativeTokenProvider.swift
+++ b/Sources/OAuth2/PlatformNativeTokenProvider.swift
@@ -18,9 +18,9 @@ import Foundation
 import AuthenticationServices
 
 public struct NativeCredentials: Codable, CodeExchangeInfo, RefreshExchangeInfo {
-  public let clientID: String
+  let clientID: String
   let authorizeURL: String
-  public let accessTokenURL: String
+  let accessTokenURL: String
   let callbackScheme: String
   enum CodingKeys: String, CodingKey {
     case clientID = "client_id"
@@ -31,7 +31,7 @@ public struct NativeCredentials: Codable, CodeExchangeInfo, RefreshExchangeInfo 
   var redirectURI: String {
     callbackScheme + ":/oauth2redirect"
   }
-  public var clientSecret: String {
+  var clientSecret: String {
     ""
   }
 }
@@ -83,6 +83,13 @@ public class PlatformNativeTokenProvider: TokenProvider {
   public func saveToken(_ filename: String) throws {
     if let token = token {
       try token.save(filename)
+    }
+  }
+
+  public func refreshToken(_ filename: String) throws {
+    if let token = token, token.isExpired() {
+      self.token = try Refresh(token: token).exchange(info: credentials)
+      try saveToken(filename)
     }
   }
 

--- a/Sources/OAuth2/PlatformNativeTokenProvider.swift
+++ b/Sources/OAuth2/PlatformNativeTokenProvider.swift
@@ -17,10 +17,10 @@ import Dispatch
 import Foundation
 import AuthenticationServices
 
-struct NativeCredentials: Codable, CodeExchangeInfo {
-  let clientID: String
+public struct NativeCredentials: Codable, CodeExchangeInfo, RefreshExchangeInfo {
+  public let clientID: String
   let authorizeURL: String
-  let accessTokenURL: String
+  public let accessTokenURL: String
   let callbackScheme: String
   enum CodingKeys: String, CodingKey {
     case clientID = "client_id"
@@ -31,7 +31,7 @@ struct NativeCredentials: Codable, CodeExchangeInfo {
   var redirectURI: String {
     callbackScheme + ":/oauth2redirect"
   }
-  var clientSecret: String {
+  public var clientSecret: String {
     ""
   }
 }

--- a/Sources/OAuth2/Refresh.swift
+++ b/Sources/OAuth2/Refresh.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
 
 protocol RefreshExchangeInfo {
   var accessTokenURL: String { get }

--- a/Sources/OAuth2/Refresh.swift
+++ b/Sources/OAuth2/Refresh.swift
@@ -14,33 +14,30 @@
 
 import Foundation
 
-public protocol RefreshExchangeInfo {
+protocol RefreshExchangeInfo {
   var accessTokenURL: String { get }
   var clientID: String { get }
   var clientSecret: String { get }
 }
 
-public class Refresh {
+class Refresh {
     
   let token: String
     
-  public convenience init?(token data: Data) {
-    if let token = try? JSONDecoder().decode(Token.self, from: data) {
-      self.init(token: token)
-    } else {
-      return nil
-    }
+  convenience init(token data: Data) throws {
+    let token = try JSONDecoder().decode(Token.self, from: data)
+    try self.init(token: token)
   }
   
-  init?(token: Token) {
+  init(token: Token) throws {
     if let rt = token.RefreshToken {
       self.token = rt
-      return
+    } else {
+        throw AuthError.noRefreshToken
     }
-    return nil
   }
-  
-  public func exchange(info: RefreshExchangeInfo) throws -> Token {
+
+  func exchange(info: RefreshExchangeInfo) throws -> Token {
     let sem = DispatchSemaphore(value: 0)
     let parameters = [
       "client_id": info.clientID,

--- a/Sources/OAuth2/Refresh.swift
+++ b/Sources/OAuth2/Refresh.swift
@@ -1,0 +1,98 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+public protocol RefreshExchangeInfo {
+  var accessTokenURL: String { get }
+  var clientID: String { get }
+  var clientSecret: String { get }
+}
+
+public class Refresh {
+    
+  let token: String
+    
+  public convenience init?(token data: Data) {
+    if let token = try? JSONDecoder().decode(Token.self, from: data) {
+      self.init(token: token)
+    } else {
+      return nil
+    }
+  }
+  
+  init?(token: Token) {
+    if let rt = token.RefreshToken {
+      self.token = rt
+      return
+    }
+    return nil
+  }
+  
+  public func exchange(info: RefreshExchangeInfo) throws -> Token {
+    let sem = DispatchSemaphore(value: 0)
+    let parameters = [
+      "client_id": info.clientID,
+      "client_secret": info.clientSecret,
+      "grant_type": "refresh_token",
+      "refresh_token": self.token,
+    ]
+    let token = info.clientID + ":" + info.clientSecret
+    // some providers require the client id and secret in the authorization header
+    let authorization = "Basic " + String(data: token.data(using: .utf8)!.base64EncodedData(), encoding: .utf8)!
+    var responseData: Data?
+    var contentType: String?
+    Connection.performRequest(
+      method: "POST",
+      urlString: info.accessTokenURL,
+      parameters: parameters,
+      body: nil,
+      authorization: authorization
+    ) { data, response, _ in
+      if let response = response as? HTTPURLResponse {
+        for (k, v) in response.allHeaderFields {
+          // Explicitly-lowercasing seems like it should be unnecessary,
+          // but some services returned "Content-Type" and others sent "content-type".
+          if (k as! String).lowercased() == "content-type" {
+            contentType = v as? String
+          }
+        }
+      }
+      responseData = data
+      sem.signal()
+    }
+    _ = sem.wait(timeout: DispatchTime.distantFuture)
+    if let contentType = contentType, contentType.contains("application/json") {
+      let decoder = JSONDecoder()
+      let token = try! decoder.decode(Token.self, from: responseData!)
+      return token
+    } else { // assume "application/x-www-form-urlencoded"
+      guard let responseData = responseData else {
+        throw AuthError.unknownError
+      }
+      guard let queryParameters = String(data: responseData, encoding: .utf8) else {
+        throw AuthError.unknownError
+      }
+      guard let urlComponents = URLComponents(string: "http://example.com?" + queryParameters) else {
+        throw AuthError.unknownError
+      }
+      var token = Token(urlComponents: urlComponents)
+      if token.RefreshToken == nil {
+        // Google refresh tokens are persistent
+        token.RefreshToken = self.token
+      }
+      return token
+    }
+  }
+}

--- a/Sources/OAuth2/Token.swift
+++ b/Sources/OAuth2/Token.swift
@@ -39,13 +39,20 @@ public struct Token : Codable {
     return timeToExpiry() > 0
   }
 
-  
   public func timeToExpiry() -> TimeInterval {
     guard let expiresIn = ExpiresIn, let creationTime = CreationTime else {
       return 0.0 // if we dont know when it expires, assume its expired
     }
     let expireDate = creationTime.addingTimeInterval(TimeInterval(expiresIn))
     return expireDate.timeIntervalSinceNow
+  }
+    
+  public func refresh(info: RefreshExchangeInfo) -> Token? {
+    if isExpired() {
+      return try? Refresh(token: self)?.exchange(info: info)
+    } else {
+      return self
+    }
   }
   
   public init(accessToken: String) {

--- a/Sources/OAuth2/Token.swift
+++ b/Sources/OAuth2/Token.swift
@@ -36,7 +36,7 @@ public struct Token : Codable {
   }
   
   public func isExpired() -> Bool {
-    return timeToExpiry() > 0
+    return timeToExpiry() <= 0
   }
 
   public func timeToExpiry() -> TimeInterval {

--- a/Sources/OAuth2/Token.swift
+++ b/Sources/OAuth2/Token.swift
@@ -46,15 +46,7 @@ public struct Token : Codable {
     let expireDate = creationTime.addingTimeInterval(TimeInterval(expiresIn))
     return expireDate.timeIntervalSinceNow
   }
-    
-  public func refresh(info: RefreshExchangeInfo) -> Token? {
-    if isExpired() {
-      return try? Refresh(token: self)?.exchange(info: info)
-    } else {
-      return self
-    }
-  }
-  
+
   public init(accessToken: String) {
     self.AccessToken = accessToken
   }


### PR DESCRIPTION
Drafted up this idea for token refresh. I only added it to the **browser** and **native** providers because that's what I'm testing on. I am pretty sure it can generalize to `Token`, though.

The [gmail apis auth lib docs](https://developers.google.com/gmail/api/guides/handle-errors?hl=en#resolve_a_401_error_invalid_credentials) suggest that the library handles token refresh automatically. We could consider doing that here but would need to add a bit of logic in the `Connection` to inspect the response for a `401` and attempt a refresh using: https://github.com/googleapis/google-api-swift-client/pull/35. Seems like a start is add the functionality in a way that allows the client to implement it and then consider doing it automatically in this library.