### PR TITLE
Fix CreationTime not set in returned token from ServiceAccountTokenProvider

### DIFF
--- a/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
+++ b/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
@@ -109,7 +109,7 @@ public class ServiceAccountTokenProvider : TokenProvider {
         let token = try? decoder.decode(Token.self, from: data) {
         self.token = token
         self.token?.CreationTime = Date()
-        callback(token, error)
+        callback(self.token, error)
       } else {
         callback(nil, error)
       }


### PR DESCRIPTION
I noticed that when using the `ServiceAccountTokenProvider`, I was not getting a `Token` with the `CreationTime` set. Digging in, the code modifies a copy of the original `Token`, but does not return that copy to the callback. This PR fixes that by passing the copy so the callback will get a `Token` with `CreationTime`.