### PR TITLE
properly return decoding and access token errors

### DIFF
--- a/Sources/OAuth2/Code.swift
+++ b/Sources/OAuth2/Code.swift
@@ -87,9 +87,7 @@ class Code {
     }
     _ = sem.wait(timeout: DispatchTime.distantFuture)
     if let contentType = contentType, contentType.contains("application/json") {
-      let decoder = JSONDecoder()
-      let token = try! decoder.decode(Token.self, from: responseData!)
-      return token
+      return try JSONDecoder().decode(Token.self, from: responseData!)
     } else { // assume "application/x-www-form-urlencoded"
       guard let responseData = responseData else {
         throw AuthError.unknownError

--- a/Sources/OAuth2/Connection.swift
+++ b/Sources/OAuth2/Connection.swift
@@ -74,11 +74,8 @@ public class Connection {
     callback: @escaping (Data?, URLResponse?, Error?) -> Void) throws {
     
     try provider.withToken {token, err in
-      guard let token = token else {
-        return
-      }
-      guard let accessToken = token.AccessToken else {
-        return
+      guard let accessToken = token?.AccessToken else {
+        return callback(nil, nil, AuthError.unknownError)
       }
       Connection.performRequest(
         method: method,

--- a/Sources/OAuth2/GoogleRefreshTokenProvider.swift
+++ b/Sources/OAuth2/GoogleRefreshTokenProvider.swift
@@ -74,9 +74,7 @@ public class GoogleRefreshTokenProvider: TokenProvider {
     }
     _ = sem.wait(timeout: DispatchTime.distantFuture)
     // assume content type is "application/json"
-    let decoder = JSONDecoder()
-    let token = try? decoder.decode(Token.self, from: responseData!)
-    return token
+    return try JSONDecoder().decode(Token.self, from: responseData!)
   }
 
   public func withToken(_ callback: @escaping (Token?, Error?) -> Void) throws {

--- a/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
+++ b/Sources/OAuth2/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
@@ -94,7 +94,7 @@ public class ServiceAccountTokenProvider : TokenProvider {
                                       rsaKey:rsaKey)
     let json: [String: Any] = ["grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
                            "assertion": msg]
-    let data = try? JSONSerialization.data(withJSONObject: json)    
+    let data = try JSONSerialization.data(withJSONObject: json)
   
     var urlRequest = URLRequest(url:URL(string:credentials.TokenURI)!)
     urlRequest.httpMethod = "POST"
@@ -104,9 +104,8 @@ public class ServiceAccountTokenProvider : TokenProvider {
     let session = URLSession(configuration: URLSessionConfiguration.default)
     let task: URLSessionDataTask = session.dataTask(with:urlRequest)
     {(data, response, error) -> Void in
-      let decoder = JSONDecoder()
       if let data = data,
-        let token = try? decoder.decode(Token.self, from: data) {
+        let token = try? JSONDecoder().decode(Token.self, from: data) {
         self.token = token
         self.token?.CreationTime = Date()
         callback(self.token, error)


### PR DESCRIPTION
- Throw errors where it's possible to do so without changing signatures
  - In several instances, there are calls that use `try?` or `try!` within throwing functions. Changing these to `try` allows the client to gather more context about whatever issue has occurred

- Call `callback` when the access token is missing
  - Without this the client must perform the same check prior to making any API call and a failure to do so can result in unexpected behavior because the API call is never made and the client is not informed that there is an issue. This is especially relevant considering that the [documentation](https://developers.google.com/gmail/api/guides/handle-errors?hl=en#resolve_a_401_error_invalid_credentials) states: `If you are using a client library, it automatically handles token refresh.`, which is NOT accurate in the case of this particular library.