### PR TITLE
Update SwiftNIO library 2.32.x from 2.0

### DIFF
--- a/AuthLibrary.podspec
+++ b/AuthLibrary.podspec
@@ -41,7 +41,7 @@ The CocoaPods distribution supports iOS-based authentication using Google Cloud 
   s.dependency "CryptoSwift", "~> 1.0.0"
   s.dependency "BigInt", "~> 3.1.0"
   s.dependency "SwiftyBase64", "~> 1.1.1"
-  s.dependency "SwiftNIO", "2.0.0"
+  s.dependency "SwiftNIO", "~> 2.32.0"
   s.dependency "Firebase/Core"
   s.dependency "Firebase/Functions"
   s.dependency "Firebase/Auth"


### PR DESCRIPTION
## What

Update the SwiftNIO library from 2.0 to `~> 2.32.0` (= 2.32.x).

## Why

Now when I install this library to the new Xcode project and try to build, got some errors that relate to SwiftNIO library.
![Screenshot(https://user-images.githubusercontent.com/5585662/169678374-958d812d-e075-4004-933d-ac61bf95100a.png)

It seems because of using old version SwiftNIO library. So update it.

## How

At first, I tried to set SwiftNIO version as `~> 2.0` (= `2.x`) and try to install the this library, then pod installed `2.32.2`. So finally I set version as `~> 2.32.0`. Now errors are disappeared when build the project.

## Anything else

Actually, this library can't build now on new Xcode project because of bug that is reported in following issue.
https://github.com/googleapis/google-auth-library-swift/issues/60

So maybe if CI run when publish the PR, it would be failed. I plan to publish the PR which fix the above bug later but I'll add it if need to pass the CI to merge this PR.