### PR TITLE
Update the library version specified in .podspec file to be up-to-date

### DIFF
--- a/AuthLibrary.podspec
+++ b/AuthLibrary.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name = "AuthLibrary"
-  s.version = "0.5.0"
+  s.version = "0.5.2"
   s.summary = "Auth client library for Swift command-line tools, cloud services, and apps."
   s.swift_version = "5.0"
   s.ios.deployment_target = "10.0"


### PR DESCRIPTION
### Description
This PR updates the version of the library specified in the podspec to a version that includes the `ServiceAccountTokenProvider` class.
This update is crucial for [migrating to Firebase's HTTP v1 API](https://firebase.google.com/docs/cloud-messaging/migrate-v1?hl=en&_gl=1*1hl7voz*_up*MQ..*_ga*MTY1MjAwMTI4Mi4xNzE2NTE1Mzkx*_ga_CW55HF8NVT*MTcxNjUxNTM5MS4xLjAuMTcxNjUxNTM5MS4wLjAuMA..#use-credentials-to-mint-access-tokens), which requires minting access tokens.

<br>

### Context
As part of the migration to Firebase's HTTP v1 API, the `ServiceAccountTokenProvider` class is essential for generating access tokens.
Without that class, you won't be able to migrate APIs through this SDK.
**While the current version specified in the podspec is `0.5.0`, which does not include it.**

(API migration is essential because the older version of the API will end support on June 20, 2024.)

<br>

### Changes
Updated library version of the podspec from `0.5.0` to use the latest version(`0.5.2`) that includes `ServiceAccountTokenProvider`.
