### PR TITLE
Remove Firebase/Firestore dependency in .podspec file

### DIFF
--- a/AuthLibrary.podspec
+++ b/AuthLibrary.podspec
@@ -45,5 +45,4 @@ The CocoaPods distribution supports iOS-based authentication using Google Cloud 
   s.dependency "Firebase/Core"
   s.dependency "Firebase/Functions"
   s.dependency "Firebase/Auth"
-  s.dependency "Firebase/Firestore"
 end


### PR DESCRIPTION
### Context

Currently, `Firebase/FireStore` includes this library as a dependency in its podspec file,
```
s.dependency "Firebase/Firestore"
```

but it is not used anywhere.
And it's not just unused, it causes **compile errors** with objc code in existing projects.

For example, the `count` property in the `FIRAggregateQuerySnapshot.mm` code of `Firebase/FireStore` causes a compile error due to a conflict with the existing Objc's `count`.

```objc
- (NSNumber *)count {
  return (NSNumber *)[self valueForAggregateField:[FIRAggregateField aggregateFieldForCount]];
}
```

Error message
```
Multiple methods named 'count' found with mismatched result, parameter type, or attributes
```


<br>

### Changes

Therefore, I propose removing this unnecessary dependency to avoid conflicts with existing Objc code and prevent compile errors.
